### PR TITLE
Add hydration guard for remote case data

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -3,6 +3,7 @@ import { NavLink, useNavigate } from 'react-router-dom'
 import { Menu, Sun, Moon, Search } from 'lucide-react'
 import clsx from 'clsx'
 import { Toaster } from 'react-hot-toast'
+import { useHydrateCases } from '../store/cases'
 
 function useTheme() {
   const [dark, setDark] = useState(() =>
@@ -20,6 +21,7 @@ export default function Layout({ children }) {
   const [open, setOpen] = useState(true)
   const navigate = useNavigate()
   const { dark, toggle } = useTheme()
+  const hydrated = useHydrateCases()
 
   const linkClass = ({ isActive }) =>
     clsx('flex items-center gap-2 rounded-xl px-3 py-2 text-sm',
@@ -56,13 +58,25 @@ export default function Layout({ children }) {
           <nav className="card p-3 space-y-2">
             <NavLink to="/" className={linkClass}>🏠 Dashboard</NavLink>
             <NavLink to="/matters" className={linkClass}>📁 Matters</NavLink>
-            <button className="btn btn-primary w-full" onClick={() => navigate('/matters/new')}>+ New Matter</button>
+            <button
+              className="btn btn-primary w-full"
+              onClick={() => navigate('/matters/new')}
+              disabled={!hydrated}
+            >
+              + New Matter
+            </button>
           </nav>
           <div className="text-xs text-slate-500 dark:text-slate-400 mt-3 px-1">Local-first • API-backed</div>
         </aside>
 
         <main className={clsx('col-span-12', open ? 'md:col-span-9 lg:col-span-10' : 'md:col-span-12')}>
-          <div className="card p-4">{children}</div>
+          <div className="card p-4">
+            {hydrated ? children : (
+              <div className="py-24 flex flex-col items-center justify-center text-sm text-slate-500 dark:text-slate-400">
+                <span className="animate-pulse">Loading matters…</span>
+              </div>
+            )}
+          </div>
         </main>
       </div>
     </div>

--- a/src/pages/MatterForm.jsx
+++ b/src/pages/MatterForm.jsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useNavigate, useParams } from 'react-router-dom'
-import { useCases } from '../store/cases'
+import { useCases, useHydrateCases } from '../store/cases'
 import toast from 'react-hot-toast'
 
 // Zod schema for validation
@@ -39,6 +39,7 @@ const btnDefaultClasses = "btn"
 export default function MatterForm(){
   const { id } = useParams()
   const nav = useNavigate()
+  const hydrated = useHydrateCases()
   const { cases, addCase, updateCase, removeCase } = useCases()
   const current = cases.find(c=>c.id===id) || null
 
@@ -72,6 +73,15 @@ export default function MatterForm(){
       const newId = await addCase(payload)
       toast.success('Matter added'); nav(`/matters/${newId}`)
     }
+  }
+
+  if(!hydrated){
+    return (
+      <div className="p-6">
+        <h2 className="text-2xl font-bold mb-6">Loading matter…</h2>
+        <p className="text-sm text-slate-500 dark:text-slate-400">Please hold on while we fetch your cases.</p>
+      </div>
+    )
   }
 
   return (

--- a/src/pages/Matters.jsx
+++ b/src/pages/Matters.jsx
@@ -3,12 +3,13 @@ import { useNavigate } from 'react-router-dom'
 import Drawer from '../components/Drawer'
 import CaseDetails from '../components/CaseDetails'
 import DataTable from '../components/DataTable' // Assuming a generic DataTable component
-import { useCases } from '../store/cases'
+import { useCases, useHydrateCases } from '../store/cases'
 import { format } from '../lib/_utils_date' // Imported date formatter
 import { Edit3, PlusCircle } from 'lucide-react'
 
 
 export default function Matters() {
+  const hydrated = useHydrateCases()
   const { cases: rows } = useCases() // Fetches data from Zustand store
   const navigate = useNavigate()
   
@@ -87,6 +88,14 @@ export default function Matters() {
         )
     }
   ], [])
+
+  if(!hydrated){
+    return (
+      <div className="py-24 flex flex-col items-center justify-center text-sm text-slate-500 dark:text-slate-400">
+        <span className="animate-pulse">Loading matters…</span>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-4">

--- a/src/store/cases.js
+++ b/src/store/cases.js
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { create } from 'zustand'
 import { load, save } from '../lib/storage'
 import { USE_API } from '../config'
@@ -41,3 +42,15 @@ export const useCases = create((set, get) => ({
     }
   }
 }))
+
+export function useHydrateCases(){
+  const hydrated = useCases(state => state.hydrated)
+  const hydrate = useCases(state => state.hydrate)
+
+  useEffect(() => {
+    if(!USE_API || hydrated) return
+    hydrate()
+  }, [hydrate, hydrated])
+
+  return USE_API ? hydrated : true
+}


### PR DESCRIPTION
## Summary
- add a `useHydrateCases` hook to hydrate Zustand state when the API mode is enabled
- gate layout navigation and main content behind the hydration flag with a loading message
- block the matters table and matter form until hydration finishes to avoid acting on empty data

## Testing
- npm run build *(fails: `vite: Permission denied` in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ea735af483289af07b7b100e4099