### PR TITLE
Add law firm portal with authentication landing and practice pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,19 +1,70 @@
-import { Routes, Route } from 'react-router-dom'
-import Layout from './components/Layout.jsx'
-import Dashboard from './pages/Dashboard.jsx'
-import Matters from './pages/Matters.jsx'
-import MatterForm from './pages/MatterForm.jsx'
+import { useEffect, useState } from 'react'
+import { Navigate, Route, Routes } from 'react-router-dom'
+import ShellLayout from './components/ShellLayout.jsx'
+import LoginPage from './pages/LoginPage.jsx'
+import DashboardPage from './pages/DashboardPage.jsx'
+import CasesPage from './pages/CasesPage.jsx'
+import ClientsPage from './pages/ClientsPage.jsx'
+import UpcomingCasesPage from './pages/UpcomingCasesPage.jsx'
+import ResourcesPage from './pages/ResourcesPage.jsx'
 
-export default function App(){
+export default function App() {
+  const [isAuthenticated, setIsAuthenticated] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return localStorage.getItem('ad-authenticated') === 'true'
+  })
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      localStorage.setItem('ad-authenticated', 'true')
+    } else {
+      localStorage.removeItem('ad-authenticated')
+    }
+  }, [isAuthenticated])
+
+  const handleLogin = (values) => {
+    if (!values.email || !values.password) return false
+    setIsAuthenticated(true)
+    return true
+  }
+
+  const handleLogout = () => {
+    setIsAuthenticated(false)
+  }
+
   return (
-    <Layout>
-      <Routes>
-        <Route path="/" element={<Dashboard />} />
-        <Route path="/matters" element={<Matters />} />
-        <Route path="/matters/new" element={<MatterForm />} />
-        <Route path="/matters/:id" element={<MatterForm />} />
-        <Route path="*" element={<div className="p-4">Not Found</div>} />
-      </Routes>
-    </Layout>
+    <Routes>
+      <Route
+        path="/"
+        element={
+          isAuthenticated ? (
+            <Navigate to="/dashboard" replace />
+          ) : (
+            <LoginPage onSubmit={handleLogin} />
+          )
+        }
+      />
+
+      <Route
+        element={
+          isAuthenticated ? (
+            <ShellLayout onLogout={handleLogout} />
+          ) : (
+            <Navigate to="/" replace />
+          )
+        }
+      >
+        <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/cases" element={<CasesPage />} />
+        <Route path="/clients" element={<ClientsPage />} />
+        <Route path="/upcoming" element={<UpcomingCasesPage />} />
+        <Route path="/resources" element={<ResourcesPage />} />
+      </Route>
+
+      <Route
+        path="*"
+        element={<Navigate to={isAuthenticated ? '/dashboard' : '/'} replace />}
+      />
+    </Routes>
   )
 }

--- a/src/components/ShellLayout.jsx
+++ b/src/components/ShellLayout.jsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import { Link, NavLink, Outlet } from 'react-router-dom'
+import { Menu, X } from 'lucide-react'
+
+const navItems = [
+  { to: '/dashboard', label: 'Overview' },
+  { to: '/cases', label: 'Cases' },
+  { to: '/clients', label: 'Clients' },
+  { to: '/upcoming', label: 'Upcoming Hearings' },
+  { to: '/resources', label: 'Resources' },
+]
+
+export default function ShellLayout({ onLogout }) {
+  const [mobileOpen, setMobileOpen] = useState(false)
+
+  return (
+    <div className="min-h-screen bg-slate-100/80 dark:bg-slate-950 text-slate-900 dark:text-slate-100">
+      <header className="border-b border-slate-200/70 dark:border-slate-800/70 bg-white/80 dark:bg-slate-900/80 backdrop-blur">
+        <div className="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <button
+              className="md:hidden btn"
+              onClick={() => setMobileOpen((o) => !o)}
+              aria-label="Toggle navigation"
+            >
+              {mobileOpen ? <X size={18} /> : <Menu size={18} />}
+            </button>
+            <Link to="/dashboard" className="text-lg font-semibold tracking-tight">
+              Sterling &amp; Co. Law Partners
+            </Link>
+          </div>
+          <div className="hidden md:flex items-center gap-6 text-sm font-medium">
+            {navItems.map((item) => (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                className={({ isActive }) =>
+                  `hover:text-brand-600 transition ${isActive ? 'text-brand-600' : 'text-slate-600 dark:text-slate-300'}`
+                }
+              >
+                {item.label}
+              </NavLink>
+            ))}
+            <button onClick={onLogout} className="btn">Log out</button>
+          </div>
+        </div>
+        {mobileOpen && (
+          <nav className="md:hidden border-t border-slate-200/70 dark:border-slate-800/70 bg-white dark:bg-slate-900">
+            <ul className="px-4 py-3 space-y-2">
+              {navItems.map((item) => (
+                <li key={item.to}>
+                  <NavLink
+                    to={item.to}
+                    onClick={() => setMobileOpen(false)}
+                    className={({ isActive }) =>
+                      `block rounded-lg px-3 py-2 text-sm font-medium ${
+                        isActive ? 'bg-brand-600/10 text-brand-700 dark:text-brand-300' : 'text-slate-700 dark:text-slate-200'
+                      }`
+                    }
+                  >
+                    {item.label}
+                  </NavLink>
+                </li>
+              ))}
+              <li>
+                <button onClick={onLogout} className="btn w-full" type="button">
+                  Log out
+                </button>
+              </li>
+            </ul>
+          </nav>
+        )}
+      </header>
+
+      <main className="max-w-6xl mx-auto px-4 py-10">
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/src/data/firmData.js
+++ b/src/data/firmData.js
@@ -1,0 +1,100 @@
+export const team = [
+  { name: 'Alicia Sterling', role: 'Managing Partner', phone: '+91 98765 32101', email: 'alicia@sterlinglaw.com' },
+  { name: 'Rohit Kumar', role: 'Senior Associate', phone: '+91 98220 88441', email: 'rohit@sterlinglaw.com' },
+  { name: 'Meera Patel', role: 'Litigation Lead', phone: '+91 98110 22456', email: 'meera@sterlinglaw.com' },
+]
+
+export const caseSummaries = [
+  {
+    id: 'CIV/2381/2024',
+    client: 'Blue Harbor Logistics',
+    opponent: 'Port Trust Authority',
+    practiceArea: 'Commercial Dispute',
+    nextDate: '2024-06-21',
+    courtroom: 'Bombay High Court, Courtroom 5',
+    status: 'Evidence Submission',
+    notes: 'Expert witness affidavit due two days before hearing.'
+  },
+  {
+    id: 'CRL/0175/2024',
+    client: 'Rahul Desai',
+    opponent: 'State of Maharashtra',
+    practiceArea: 'Criminal Defence',
+    nextDate: '2024-07-03',
+    courtroom: 'Sessions Court Mumbai, Court 12',
+    status: 'Arguments Scheduled',
+    notes: 'Coordinate with counsel for bail extension paperwork.'
+  },
+  {
+    id: 'FAM/8842/2023',
+    client: 'Priya Nair',
+    opponent: 'Anil Nair',
+    practiceArea: 'Family Law',
+    nextDate: '2024-06-27',
+    courtroom: 'Family Court Ernakulam',
+    status: 'Mediation Review',
+    notes: 'Prepare updated child custody plan and asset disclosures.'
+  },
+]
+
+export const clients = [
+  {
+    name: 'Blue Harbor Logistics',
+    contact: 'Rakesh Menon',
+    phone: '+91 90044 88990',
+    email: 'rakesh@blueharbor.in',
+    notes: 'Retained for long-term commercial disputes and compliance.'
+  },
+  {
+    name: 'Rahul Desai',
+    contact: 'Self',
+    phone: '+91 99112 77654',
+    email: 'rahul.desai@gmail.com',
+    notes: 'Criminal defence client with ongoing compliance requirements.'
+  },
+  {
+    name: 'Priya Nair',
+    contact: 'Self',
+    phone: '+91 98980 12354',
+    email: 'priya.nair@gmail.com',
+    notes: 'Family law client requiring weekly updates.'
+  },
+  {
+    name: 'Sunrise Developers',
+    contact: 'Nitin Sharma',
+    phone: '+91 99887 33001',
+    email: 'nitin@sunriseinfra.com',
+    notes: 'Retainer for real-estate contract vetting and due diligence.'
+  }
+]
+
+export const tasks = [
+  { title: 'File written submissions for CIV/2381/2024', owner: 'Rohit Kumar', due: '2024-06-18' },
+  { title: 'Client prep call for CRL/0175/2024', owner: 'Meera Patel', due: '2024-06-19' },
+  { title: 'Draft retainer renewal for Sunrise Developers', owner: 'Alicia Sterling', due: '2024-06-20' },
+]
+
+export const resources = [
+  {
+    title: 'Court Filing Checklist',
+    description: 'Step-by-step checklist for filings across the Bombay High Court and district courts.',
+    link: '#'
+  },
+  {
+    title: 'Client Onboarding Template',
+    description: 'Pre-drafted questionnaire and engagement letter for new corporate clients.',
+    link: '#'
+  },
+  {
+    title: 'Litigation Calendar SOP',
+    description: 'Standard operating procedure for maintaining cause lists and alerts.',
+    link: '#'
+  }
+]
+
+export const stats = {
+  activeMatters: 48,
+  hearingsThisWeek: 9,
+  filingsPending: 6,
+  teamUtilisation: 82
+}

--- a/src/pages/CasesPage.jsx
+++ b/src/pages/CasesPage.jsx
@@ -1,0 +1,51 @@
+import dayjs from 'dayjs'
+import { caseSummaries } from '../data/firmData'
+
+export default function CasesPage() {
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Active Case Files</h1>
+        <p className="text-sm text-slate-500">Centralised list of ongoing matters with next steps and hearing schedules.</p>
+      </header>
+
+      <div className="card overflow-hidden">
+        <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800 text-sm">
+          <thead className="bg-slate-50/70 dark:bg-slate-900/70 text-left text-xs font-semibold uppercase tracking-wider">
+            <tr>
+              <th className="px-4 py-3">Case number</th>
+              <th className="px-4 py-3">Client</th>
+              <th className="px-4 py-3">Opponent</th>
+              <th className="px-4 py-3">Practice area</th>
+              <th className="px-4 py-3">Next hearing</th>
+              <th className="px-4 py-3">Status</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100 dark:divide-slate-800 bg-white/60 dark:bg-slate-950/50">
+            {caseSummaries.map((item) => (
+              <tr key={item.id} className="hover:bg-brand-50/50 dark:hover:bg-slate-800/60">
+                <td className="px-4 py-4 font-medium text-brand-700 dark:text-brand-200">{item.id}</td>
+                <td className="px-4 py-4">{item.client}</td>
+                <td className="px-4 py-4">{item.opponent}</td>
+                <td className="px-4 py-4">
+                  <span className="badge">{item.practiceArea}</span>
+                </td>
+                <td className="px-4 py-4">{dayjs(item.nextDate).format('DD MMM YYYY')}</td>
+                <td className="px-4 py-4 text-slate-600 dark:text-slate-300">{item.status}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <section className="card p-6 space-y-4">
+        <h2 className="text-lg font-semibold">Case management protocols</h2>
+        <ul className="list-disc pl-5 text-sm text-slate-600 dark:text-slate-300 space-y-2">
+          <li>Digitised cause lists with automated reminders 48 hours before each hearing.</li>
+          <li>Standard evidence bundles stored in the firm drive with tiered access controls.</li>
+          <li>Hearing notes template to capture courtroom updates immediately after proceedings.</li>
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/src/pages/ClientsPage.jsx
+++ b/src/pages/ClientsPage.jsx
@@ -1,0 +1,36 @@
+import { clients } from '../data/firmData'
+
+export default function ClientsPage() {
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Client Directory</h1>
+        <p className="text-sm text-slate-500">Comprehensive profile of active and retainer clients with communication notes.</p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {clients.map((client) => (
+          <article key={client.email} className="card p-5 space-y-2">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">{client.name}</h2>
+            <p className="text-sm text-slate-500">Primary contact: {client.contact}</p>
+            <div className="text-sm text-slate-600 dark:text-slate-300 space-y-1">
+              <p>{client.phone}</p>
+              <p>{client.email}</p>
+            </div>
+            <p className="text-sm text-slate-500">{client.notes}</p>
+            <button className="btn btn-primary text-sm">View engagement</button>
+          </article>
+        ))}
+      </div>
+
+      <section className="card p-6 space-y-3 text-sm text-slate-600 dark:text-slate-300">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Client relationship essentials</h2>
+        <ul className="list-disc pl-5 space-y-2">
+          <li>Every new client receives an onboarding questionnaire and conflict check approval.</li>
+          <li>Matters are tagged to responsible partners with monthly review calls scheduled.</li>
+          <li>Secure document vault ensures clients can upload evidence and track progress.</li>
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,0 +1,97 @@
+import { caseSummaries, stats, tasks, team } from '../data/firmData'
+import dayjs from 'dayjs'
+
+const statCards = [
+  { label: 'Active Matters', key: 'activeMatters' },
+  { label: 'Hearings This Week', key: 'hearingsThisWeek' },
+  { label: 'Filings Pending', key: 'filingsPending' },
+  { label: 'Team Utilisation', key: 'teamUtilisation', suffix: '%' },
+]
+
+export default function DashboardPage() {
+  return (
+    <div className="space-y-8">
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {statCards.map((card) => (
+          <article key={card.key} className="card p-5">
+            <p className="text-xs uppercase tracking-wide text-slate-500">{card.label}</p>
+            <p className="mt-3 text-3xl font-semibold text-slate-900 dark:text-white">
+              {stats[card.key]}
+              {card.suffix ?? ''}
+            </p>
+          </article>
+        ))}
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-3">
+        <article className="card p-5 lg:col-span-2 space-y-4">
+          <header className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold">Priority Hearings</h2>
+            <span className="text-xs text-slate-500">Automatically synced from court calendars</span>
+          </header>
+          <div className="space-y-4">
+            {caseSummaries.map((item) => (
+              <div key={item.id} className="rounded-2xl border border-slate-200/70 dark:border-slate-800/70 p-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-brand-600">{item.id}</p>
+                    <p className="text-base font-medium">{item.client} vs {item.opponent}</p>
+                  </div>
+                  <span className="badge">{item.practiceArea}</span>
+                </div>
+                <dl className="mt-3 grid gap-x-6 gap-y-2 sm:grid-cols-3 text-sm text-slate-600 dark:text-slate-300">
+                  <div>
+                    <dt className="font-medium text-slate-500">Next hearing</dt>
+                    <dd>{dayjs(item.nextDate).format('DD MMM YYYY')}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-medium text-slate-500">Courtroom</dt>
+                    <dd>{item.courtroom}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-medium text-slate-500">Status</dt>
+                    <dd>{item.status}</dd>
+                  </div>
+                </dl>
+                <p className="mt-3 text-sm text-slate-500">{item.notes}</p>
+              </div>
+            ))}
+          </div>
+        </article>
+
+        <aside className="space-y-6">
+          <article className="card p-5 space-y-4">
+            <h2 className="text-lg font-semibold">Action Items</h2>
+            <ul className="space-y-3 text-sm">
+              {tasks.map((task) => (
+                <li key={task.title} className="flex items-start gap-3">
+                  <span className="mt-1 h-2 w-2 rounded-full bg-brand-600" />
+                  <div>
+                    <p className="font-medium text-slate-900 dark:text-white">{task.title}</p>
+                    <p className="text-xs text-slate-500">
+                      Owner: {task.owner} • Due {dayjs(task.due).format('DD MMM')}
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </article>
+
+          <article className="card p-5 space-y-4">
+            <h2 className="text-lg font-semibold">Key Contacts</h2>
+            <ul className="space-y-3 text-sm text-slate-600 dark:text-slate-300">
+              {team.map((member) => (
+                <li key={member.email} className="rounded-xl border border-slate-200/70 dark:border-slate-800/70 p-3">
+                  <p className="font-semibold text-slate-900 dark:text-white">{member.name}</p>
+                  <p>{member.role}</p>
+                  <p className="text-xs mt-1">{member.phone}</p>
+                  <p className="text-xs">{member.email}</p>
+                </li>
+              ))}
+            </ul>
+          </article>
+        </aside>
+      </section>
+    </div>
+  )
+}

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,0 +1,66 @@
+import { useState } from 'react'
+
+export default function LoginPage({ onSubmit }) {
+  const [form, setForm] = useState({ email: '', password: '' })
+  const [error, setError] = useState('')
+
+  const handleChange = (event) => {
+    const { name, value } = event.target
+    setForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    const success = onSubmit(form)
+    if (!success) {
+      setError('Please provide both email and password to continue.')
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-100 via-white to-slate-100">
+      <div className="max-w-md w-full bg-white/90 backdrop-blur rounded-3xl border border-slate-200 shadow-lg p-8 space-y-6">
+        <header className="space-y-2 text-center">
+          <h1 className="text-2xl font-semibold text-slate-900">Sterling &amp; Co. Law Partners</h1>
+          <p className="text-sm text-slate-500">Secure portal for case tracking, client management, and firm operations.</p>
+        </header>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-slate-700" htmlFor="email">Email</label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              className="input"
+              placeholder="you@sterlinglaw.com"
+              value={form.email}
+              onChange={handleChange}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-slate-700" htmlFor="password">Password</label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              className="input"
+              placeholder="Enter your password"
+              value={form.password}
+              onChange={handleChange}
+            />
+          </div>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <button type="submit" className="btn btn-primary w-full">Sign in</button>
+        </form>
+
+        <div className="text-xs text-slate-400 text-center">
+          Protected access. Contact the firm administrator to reset your credentials.
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/ResourcesPage.jsx
+++ b/src/pages/ResourcesPage.jsx
@@ -1,0 +1,54 @@
+import { resources, team } from '../data/firmData'
+
+export default function ResourcesPage() {
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Firm Operations &amp; Resources</h1>
+        <p className="text-sm text-slate-500">Guidelines, templates, and administrative details that keep the law firm running smoothly.</p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        {resources.map((item) => (
+          <article key={item.title} className="card p-5 space-y-2">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">{item.title}</h2>
+            <p className="text-sm text-slate-500">{item.description}</p>
+            <a href={item.link} className="text-sm text-brand-600 hover:underline">Download reference</a>
+          </article>
+        ))}
+      </section>
+
+      <section className="card p-6 space-y-4">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Support desks</h2>
+        <div className="grid gap-4 md:grid-cols-3 text-sm text-slate-600 dark:text-slate-300">
+          <div>
+            <h3 className="font-semibold text-slate-900 dark:text-white">Court Filings</h3>
+            <p>Email: filings@sterlinglaw.com</p>
+            <p>Turnaround: 24 hours for district courts, 48 hours for High Courts</p>
+          </div>
+          <div>
+            <h3 className="font-semibold text-slate-900 dark:text-white">Client Services</h3>
+            <p>Email: clients@sterlinglaw.com</p>
+            <p>Availability: Monday to Saturday, 9.00 am – 7.00 pm</p>
+          </div>
+          <div>
+            <h3 className="font-semibold text-slate-900 dark:text-white">Research Desk</h3>
+            <p>Email: research@sterlinglaw.com</p>
+            <p>Specialisation: Case law updates, legislative tracking, sectoral alerts</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="card p-6 space-y-3 text-sm text-slate-600 dark:text-slate-300">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Emergency contacts</h2>
+        <ul className="list-disc pl-5 space-y-2">
+          {team.map((member) => (
+            <li key={member.email}>
+              {member.name} — {member.phone}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/src/pages/UpcomingCasesPage.jsx
+++ b/src/pages/UpcomingCasesPage.jsx
@@ -1,0 +1,57 @@
+import dayjs from 'dayjs'
+import { caseSummaries } from '../data/firmData'
+
+const timeline = caseSummaries
+  .slice()
+  .sort((a, b) => new Date(a.nextDate) - new Date(b.nextDate))
+
+export default function UpcomingCasesPage() {
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Upcoming Hearings Timeline</h1>
+        <p className="text-sm text-slate-500">Stay ahead of hearing preparation, evidence submissions, and courtroom logistics.</p>
+      </header>
+
+      <div className="card p-6 space-y-6">
+        <ol className="relative border-l border-slate-200 dark:border-slate-700 pl-6 space-y-6">
+          {timeline.map((item) => (
+            <li key={item.id} className="ml-4">
+              <div className="absolute -left-1 mt-1 h-3 w-3 rounded-full border-2 border-white bg-brand-600" />
+              <p className="text-xs uppercase tracking-wide text-slate-500">
+                {dayjs(item.nextDate).format('dddd, DD MMM YYYY')}
+              </p>
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
+                {item.client} vs {item.opponent}
+              </h2>
+              <p className="text-sm text-slate-500">{item.courtroom}</p>
+              <div className="mt-2 grid gap-x-6 gap-y-2 sm:grid-cols-3 text-sm text-slate-600 dark:text-slate-300">
+                <div>
+                  <p className="font-medium text-slate-500">Status</p>
+                  <p>{item.status}</p>
+                </div>
+                <div>
+                  <p className="font-medium text-slate-500">Preparation</p>
+                  <p>{item.notes}</p>
+                </div>
+                <div>
+                  <p className="font-medium text-slate-500">Practice area</p>
+                  <p>{item.practiceArea}</p>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </div>
+
+      <section className="card p-6 space-y-3 text-sm text-slate-600 dark:text-slate-300">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Hearing preparedness checklist</h2>
+        <ul className="list-disc pl-5 space-y-2">
+          <li>Review cause list 72 hours prior and confirm advocate-on-record availability.</li>
+          <li>Ensure briefing notes and exhibits are uploaded to the shared drive with version control.</li>
+          <li>Coordinate travel logistics for outstation matters with the administrative desk.</li>
+        </ul>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- replace the app routing with a login-first flow that persists session state and guards the protected routes
- add a responsive shell layout with navigation for cases, clients, upcoming hearings, and firm resources
- introduce curated data-driven pages that surface case tables, client profiles, hearing timelines, and operational checklists

## Testing
- npm run build *(fails: local Vite binary unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ef33ae2fd483289f1b4bba3d06428b