### PR TITLE
Surface cached portal data before API load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.vscode/
+.idea/
+*.sw?
+.DS_Store
+
+# Local env files
+.env
+.env.local
+
+# Backend artifacts
+server/data/
+

--- a/README.md
+++ b/README.md
@@ -1,25 +1,119 @@
-# Advocate Diary — Vite + React + Tailwind
+# Pasha Law Senate Portal
 
-Local-first diary for advocates. Optional API sync with Express + SQLite.
+Secure case management portal for Pasha Law Senate with a React front-end and an Express + SQLite backend.
 
-## Quickstart (Windows)
-```powershell
+## Requirements
+- Node.js 18+
+- npm 9+
+
+## Installation
+Install the dependencies for both the client and the API:
+
+```bash
 npm install
+npm --prefix server install
+```
+
+## Backend configuration
+1. Copy `server/.env.example` to `server/.env` and adjust values if required. The defaults provision an administrator account at `admin@pashalawsenate.com` with the password `changeMe123` and allow requests from `http://localhost:5173`.
+2. Start the API:
+   ```bash
+   npm --prefix server run dev
+   ```
+   The server listens on the configured `PORT` (4000 by default) and stores its SQLite database in `server/data/pasha-law-senate.db`.
+
+### Docker deployment
+The `server/Dockerfile` packages the Express API with the SQLite CLI and the build toolchain required for the `better-sqlite3` dependency. Build and run the container from the repository root:
+
+```bash
+docker build -t pasha-law-senate-api server
+docker run --rm -p 4000:4000 --env-file server/.env pasha-law-senate-api
+```
+
+To persist the SQLite database outside the container, mount a host volume and point `DATABASE_PATH` at the mounted location:
+
+```bash
+docker run --rm -p 4000:4000 \
+  --env-file server/.env \
+  -v $(pwd)/server/data:/data \
+  -e DATABASE_PATH=/data/pasha-law-senate.db \
+  pasha-law-senate-api
+```
+
+## Front-end configuration
+The client automatically targets `http://localhost:4000` when no API base URL is supplied. To point the UI at a different host, create a `.env.local` file with:
+
+```bash
+VITE_API_BASE_URL=http://your-api-host:port
+```
+
+## Running the app locally
+In a separate terminal, launch the Vite development server:
+
+```bash
 npm run dev
 ```
-Then open the printed URL (default `http://localhost:5173`).
 
-## Toggle backend API
-1. Start the backend (see backend README).
-2. Edit `src/config.js` and set:
-```js
-export const USE_API = true
-export const API_BASE = 'http://localhost:4000/api'
-```
-3. Restart `npm run dev`.
+Open the printed URL (defaults to `http://localhost:5173`) and sign in with the administrator credentials from the backend configuration. All case, client, resource, and support desk operations persist to the SQLite database via the API.
 
-## Build
-```powershell
+## Building for production
+```bash
 npm run build
-npm run preview
 ```
+This command compiles the React application into static assets under `dist/`.
+
+## API reference
+The backend exposes REST endpoints under `/api` for authentication, metrics, cases, clients, tasks, team contacts, resources, and support desks. See `server/src/server.js` for the full route list.
+
+## Database internals
+The Express API persists all portal data to a SQLite database located at `server/data/pasha-law-senate.db` by default (or the path
+provided via `DATABASE_PATH`). The schema is managed in `server/src/database.js` and includes the following tables:
+
+- `users` & `sessions` – store staff credentials with salted+hashed passwords and active session tokens.
+- `stats` – key/value metrics for dashboard KPIs such as active matters, hearings this week, pending filings, and team utilisation.
+- `cases`, `clients`, `tasks`, `team_members`, `resources`, `support_desks` – structured records for the operational data that powers
+  each portal page.
+
+The module exposes helpers that:
+
+- Seed default KPI keys and the initial administrator account (`seedDefaults`).
+- Create, lookup, and destroy user sessions as well as verify passwords with `scrypt`-based hashing.
+- Fetch the complete portal dataset (`getPortalData`) and normalise it before returning it to the client.
+- Upsert entire datasets in a single transaction (`replacePortalData`) so offline changes can be synced back to the server safely.
+- Provide fine-grained CRUD helpers (`createCase`, `createClient`, `createTask`, `createTeamMember`, `createResource`,
+  `createSupportDesk`, and matching `remove*` helpers) used by the REST routes.
+
+All mutation helpers validate and sanitise inputs—ensuring IDs, timestamps, and optional fields are populated consistently—before
+writing them to SQLite. This keeps the database resilient whether the data originates from the live API or a later offline sync.
+
+## Deploying the backend to Render
+The repository includes a `render.yaml` blueprint for provisioning the API. The default blueprint targets the free plan so it leaves
+persistent disks disabled—Render only allows disks on paid plans. If you are on the free tier you can deploy the API without a disk,
+but the SQLite database will be recreated on each deploy. Teams that need durable storage can manually attach a disk in the Render
+dashboard and then set `DATABASE_PATH` to the mounted location.
+
+To deploy manually:
+
+1. Create a new **Web Service** from this repository and point the root directory to `server`.
+2. Use `npm install` as the build command and `npm run start` as the start command.
+3. Add the following environment variables:
+   - `CLIENT_ORIGIN` pointing at your front-end host (for example, the Render static site URL). You can provide multiple
+     origins by separating them with commas (e.g. `https://app.example.com,https://staging.example.com`) or use `*` to allow
+     any origin when testing.
+   - Optionally override `DATABASE_PATH` (only required when a disk is attached), `ADMIN_EMAIL`, `ADMIN_PASSWORD`, and
+     `SESSION_TTL_HOURS`.
+4. Deploy the service. If no disk is attached, data lives on the ephemeral filesystem and resets when the service redeploys. With a
+   mounted disk you can persist `DATABASE_PATH` on the attached volume to retain data across deploys.
+
+When hosting the React app separately (such as a Render Static Site), set `VITE_API_BASE_URL` in the front-end environment to the
+API's public URL so requests are sent to the live backend.
+
+### Troubleshooting Render deploys
+- **Build succeeds but requests still hit offline mode** – double-check `VITE_API_BASE_URL` on the front-end and the entries in
+  `CLIENT_ORIGIN` on the API match the deployed domains (remove trailing slashes when configuring them). The UI falls back to
+  local storage whenever it cannot reach the backend.
+- **Disk configuration errors** – Render blocks persistent disks on the free plan. Deploy without a disk or upgrade the service plan
+  before reapplying a disk-backed blueprint.
+- **Native module build failures** – `better-sqlite3` needs build tools available. Render’s Node environment includes them by default,
+  but if a custom Docker environment is used ensure `build-essential` and `python3` are installed.
+

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "version": "0.0.3",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview"
+    "dev": "node ./node_modules/vite/bin/vite.js",
+    "build": "node ./node_modules/vite/bin/vite.js build",
+    "preview": "node ./node_modules/vite/bin/vite.js preview"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,13 @@
+services:
+  - type: web
+    name: pasha-law-senate-api
+    env: node
+    rootDir: server
+    plan: free
+    buildCommand: npm install
+    startCommand: npm run start
+    envVars:
+      - key: NODE_VERSION
+        value: 18
+      - key: CLIENT_ORIGIN
+        value: https://your-frontend-host.example

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.DS_Store
+.env
+.env.local
+data

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,8 @@
+PORT=4000
+# Accept a single origin, a comma-separated list, or * to allow all origins.
+CLIENT_ORIGIN=http://localhost:5173
+ADMIN_EMAIL=admin@pashalawsenate.com
+ADMIN_PASSWORD=changeMe123
+SESSION_TTL_HOURS=24
+# Uncomment to override the SQLite location (defaults to ./data/pasha-law-senate.db)
+# DATABASE_PATH=/var/data/pasha-law-senate.db

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,28 @@
+# Use an official Node runtime as a parent image
+FROM node:20-slim
+
+# Install system packages required to compile better-sqlite3 and provide the sqlite3 CLI
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    python3 \
+    sqlite3 \
+  && rm -rf /var/lib/apt/lists/*
+
+# Create app directory
+WORKDIR /app
+
+# Install app dependencies
+COPY package*.json ./
+RUN npm install --omit=dev
+
+# Bundle app source
+COPY src ./src
+COPY .env.example ./
+
+ENV NODE_ENV=production
+ENV PORT=4000
+
+EXPOSE 4000
+
+CMD ["node", "src/index.js"]

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "pasha-law-senate-backend",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/index.js",
+  "scripts": {
+    "dev": "nodemon src/index.js",
+    "start": "node src/index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "helmet": "^7.1.0",
+    "better-sqlite3": "^9.4.1"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.3"
+  }
+}

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -1,0 +1,40 @@
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+const numberFromEnv = (value, fallback) => {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+const stringFromEnv = (value, fallback = '') => {
+  if (!value) return fallback
+  const trimmed = String(value).trim()
+  return trimmed || fallback
+}
+
+const parseOrigins = (value) => {
+  if (!value) return []
+  return String(value)
+    .split(',')
+    .map((item) => item.trim())
+    .map((item) => item.replace(/\/$/, ''))
+    .filter(Boolean)
+}
+
+const DEFAULT_CLIENT_ORIGINS = ['http://localhost:5173']
+
+const resolvedOrigins = parseOrigins(process.env.CLIENT_ORIGIN)
+const clientOrigins = resolvedOrigins.length ? resolvedOrigins : DEFAULT_CLIENT_ORIGINS
+const allowAnyOrigin = clientOrigins.includes('*')
+
+export const config = {
+  port: numberFromEnv(process.env.PORT, 4000),
+  clientOrigin: clientOrigins[0] || '',
+  clientOrigins,
+  allowAnyOrigin,
+  adminEmail: process.env.ADMIN_EMAIL || 'admin@pashalawsenate.com',
+  adminPassword: process.env.ADMIN_PASSWORD || 'changeMe123',
+  sessionTtlHours: numberFromEnv(process.env.SESSION_TTL_HOURS, 24),
+  databasePath: stringFromEnv(process.env.DATABASE_PATH),
+}

--- a/server/src/database.js
+++ b/server/src/database.js
@@ -1,0 +1,730 @@
+import fs from 'fs'
+import path from 'path'
+import Database from 'better-sqlite3'
+import { randomUUID, randomBytes, scryptSync, timingSafeEqual } from 'crypto'
+import { fileURLToPath } from 'url'
+import { config } from './config.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const DEFAULT_DB_DIR = path.join(__dirname, '..', 'data')
+const DEFAULT_DB_FILENAME = 'pasha-law-senate.db'
+
+const normaliseDatabasePath = () => {
+  const configured = config.databasePath
+  if (!configured) {
+    return path.join(DEFAULT_DB_DIR, DEFAULT_DB_FILENAME)
+  }
+
+  const endsWithSeparator = configured.endsWith('/') || configured.endsWith('\\')
+  const withFilename = endsWithSeparator
+    ? path.join(configured, DEFAULT_DB_FILENAME)
+    : configured
+
+  if (path.isAbsolute(withFilename)) {
+    return withFilename
+  }
+
+  return path.join(__dirname, '..', withFilename)
+}
+
+const databasePath = normaliseDatabasePath()
+const databaseDir = path.dirname(databasePath)
+
+fs.mkdirSync(databaseDir, { recursive: true })
+
+if (!config.databasePath) {
+  console.warn(
+    `Using default SQLite location at ${databasePath}. Attach a persistent disk and set DATABASE_PATH to retain data across deployments.`
+  )
+}
+
+export const db = new Database(databasePath)
+db.pragma('journal_mode = WAL')
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    name TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+
+  CREATE TABLE IF NOT EXISTS sessions (
+    token TEXT PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+  );
+
+  CREATE TABLE IF NOT EXISTS stats (
+    key TEXT PRIMARY KEY,
+    value REAL NOT NULL DEFAULT 0
+  );
+
+  CREATE TABLE IF NOT EXISTS cases (
+    id TEXT PRIMARY KEY,
+    case_number TEXT NOT NULL,
+    client TEXT NOT NULL,
+    opponent TEXT,
+    practice_area TEXT,
+    next_date TEXT,
+    status TEXT,
+    courtroom TEXT,
+    notes TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+
+  CREATE TABLE IF NOT EXISTS clients (
+    id TEXT PRIMARY KEY,
+    organisation TEXT NOT NULL,
+    primary_contact TEXT,
+    email TEXT,
+    phone TEXT,
+    address TEXT,
+    notes TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+
+  CREATE TABLE IF NOT EXISTS tasks (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    owner TEXT NOT NULL,
+    due TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+
+  CREATE TABLE IF NOT EXISTS team_members (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    role TEXT NOT NULL,
+    phone TEXT,
+    email TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+
+  CREATE TABLE IF NOT EXISTS resources (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    type TEXT,
+    link TEXT,
+    owner TEXT,
+    notes TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+
+  CREATE TABLE IF NOT EXISTS support_desks (
+    id TEXT PRIMARY KEY,
+    department TEXT NOT NULL,
+    phone TEXT,
+    email TEXT,
+    hours TEXT,
+    notes TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+`)
+
+const STAT_KEYS = ['activeMatters', 'hearingsThisWeek', 'filingsPending', 'teamUtilisation']
+
+const hashPassword = (password) => {
+  const salt = randomBytes(16)
+  const hashed = scryptSync(password, salt, 64)
+  return `${salt.toString('hex')}:${hashed.toString('hex')}`
+}
+
+export const seedDefaults = () => {
+  const insertStat = db.prepare('INSERT OR IGNORE INTO stats (key, value) VALUES (?, 0)')
+  for (const key of STAT_KEYS) {
+    insertStat.run(key)
+  }
+
+  const adminEmail = config.adminEmail.toLowerCase()
+  const existingUser = db.prepare('SELECT id FROM users WHERE email = ?').get(adminEmail)
+  if (!existingUser) {
+    const passwordHash = hashPassword(config.adminPassword)
+    db.prepare('INSERT INTO users (email, password_hash, name) VALUES (?, ?, ?)').run(
+      adminEmail,
+      passwordHash,
+      'Pasha Law Senate Admin'
+    )
+  }
+}
+
+export const findUserByEmail = (email) => {
+  return db.prepare('SELECT id, email, password_hash, name FROM users WHERE email = ?').get(email.toLowerCase())
+}
+
+export const createUser = ({ email, password, name }) => {
+  const normalisedEmail = String(email || '').trim().toLowerCase()
+  const trimmedName = String(name || '').trim()
+  if (!normalisedEmail || !trimmedName) {
+    throw new Error('Name and email are required.')
+  }
+
+  const passwordValue = String(password || '')
+  const passwordHash = hashPassword(passwordValue)
+
+  try {
+    const result = db
+      .prepare('INSERT INTO users (email, password_hash, name) VALUES (?, ?, ?)')
+      .run(normalisedEmail, passwordHash, trimmedName)
+
+    return {
+      id: Number(result.lastInsertRowid),
+      email: normalisedEmail,
+      name: trimmedName,
+    }
+  } catch (error) {
+    if (error?.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+      const duplicateError = new Error('A user with this email already exists.')
+      duplicateError.code = 'USER_EXISTS'
+      throw duplicateError
+    }
+    throw error
+  }
+}
+
+export const createSession = (userId) => {
+  const token = randomUUID()
+  const createdAt = new Date()
+  const expiresAt = new Date(createdAt.getTime() + config.sessionTtlHours * 60 * 60 * 1000)
+  db.prepare('INSERT INTO sessions (token, user_id, created_at, expires_at) VALUES (?, ?, ?, ?)').run(
+    token,
+    userId,
+    createdAt.toISOString(),
+    expiresAt.toISOString()
+  )
+  return { token, createdAt: createdAt.toISOString(), expiresAt: expiresAt.toISOString() }
+}
+
+export const findSession = (token) => {
+  const session = db
+    .prepare(
+      `SELECT sessions.token, sessions.user_id, sessions.expires_at, users.name, users.email
+       FROM sessions
+       JOIN users ON users.id = sessions.user_id
+       WHERE sessions.token = ?`
+    )
+    .get(token)
+
+  if (!session) return null
+  if (new Date(session.expires_at).getTime() < Date.now()) {
+    db.prepare('DELETE FROM sessions WHERE token = ?').run(token)
+    return null
+  }
+  return session
+}
+
+export const deleteSession = (token) => {
+  db.prepare('DELETE FROM sessions WHERE token = ?').run(token)
+}
+
+const statsStatement = db.prepare('SELECT key, value FROM stats')
+
+export const getStats = () => {
+  const rows = statsStatement.all()
+  return rows.reduce((acc, row) => {
+    acc[row.key] = Number(row.value) || 0
+    return acc
+  }, {})
+}
+
+export const updateStats = (nextStats) => {
+  const update = db.prepare('UPDATE stats SET value = ? WHERE key = ?')
+  const stats = {}
+  for (const key of STAT_KEYS) {
+    const numericValue = Number(nextStats[key]) || 0
+    update.run(numericValue, key)
+    stats[key] = numericValue
+  }
+  return stats
+}
+
+const selectAll = (table) => db.prepare(`SELECT * FROM ${table} ORDER BY datetime(created_at) DESC`)
+
+const mapCase = (row) => ({
+  id: row.id,
+  caseNumber: row.case_number,
+  client: row.client,
+  opponent: row.opponent,
+  practiceArea: row.practice_area,
+  nextDate: row.next_date,
+  status: row.status,
+  courtroom: row.courtroom,
+  notes: row.notes,
+  createdAt: row.created_at,
+})
+
+const mapClient = (row) => ({
+  id: row.id,
+  organisation: row.organisation,
+  primaryContact: row.primary_contact,
+  email: row.email,
+  phone: row.phone,
+  address: row.address,
+  notes: row.notes,
+  createdAt: row.created_at,
+})
+
+const mapTask = (row) => ({
+  id: row.id,
+  title: row.title,
+  owner: row.owner,
+  due: row.due,
+  createdAt: row.created_at,
+})
+
+const mapTeamMember = (row) => ({
+  id: row.id,
+  name: row.name,
+  role: row.role,
+  phone: row.phone,
+  email: row.email,
+  createdAt: row.created_at,
+})
+
+const mapResource = (row) => ({
+  id: row.id,
+  title: row.title,
+  type: row.type,
+  link: row.link,
+  owner: row.owner,
+  notes: row.notes,
+  createdAt: row.created_at,
+})
+
+const mapSupportDesk = (row) => ({
+  id: row.id,
+  department: row.department,
+  phone: row.phone,
+  email: row.email,
+  hours: row.hours,
+  notes: row.notes,
+  createdAt: row.created_at,
+})
+
+export const getPortalData = () => ({
+  stats: getStats(),
+  cases: selectAll('cases')
+    .all()
+    .map(mapCase),
+  clients: selectAll('clients')
+    .all()
+    .map(mapClient),
+  tasks: selectAll('tasks')
+    .all()
+    .map(mapTask),
+  team: selectAll('team_members')
+    .all()
+    .map(mapTeamMember),
+  resources: selectAll('resources')
+    .all()
+    .map(mapResource),
+  supportDesks: selectAll('support_desks')
+    .all()
+    .map(mapSupportDesk),
+})
+
+const replaceStatsStatement = db.prepare(
+  'INSERT INTO stats (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value'
+)
+
+const replaceCaseStatement = db.prepare(
+  `INSERT INTO cases (id, case_number, client, opponent, practice_area, next_date, status, courtroom, notes, created_at)
+   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+   ON CONFLICT(id) DO UPDATE SET
+     case_number = excluded.case_number,
+     client = excluded.client,
+     opponent = excluded.opponent,
+     practice_area = excluded.practice_area,
+     next_date = excluded.next_date,
+     status = excluded.status,
+     courtroom = excluded.courtroom,
+     notes = excluded.notes,
+     created_at = excluded.created_at`
+)
+
+const replaceClientStatement = db.prepare(
+  `INSERT INTO clients (id, organisation, primary_contact, email, phone, address, notes, created_at)
+   VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+   ON CONFLICT(id) DO UPDATE SET
+     organisation = excluded.organisation,
+     primary_contact = excluded.primary_contact,
+     email = excluded.email,
+     phone = excluded.phone,
+     address = excluded.address,
+     notes = excluded.notes,
+     created_at = excluded.created_at`
+)
+
+const replaceTaskStatement = db.prepare(
+  `INSERT INTO tasks (id, title, owner, due, created_at)
+   VALUES (?, ?, ?, ?, ?)
+   ON CONFLICT(id) DO UPDATE SET
+     title = excluded.title,
+     owner = excluded.owner,
+     due = excluded.due,
+     created_at = excluded.created_at`
+)
+
+const replaceTeamStatement = db.prepare(
+  `INSERT INTO team_members (id, name, role, phone, email, created_at)
+   VALUES (?, ?, ?, ?, ?, ?)
+   ON CONFLICT(id) DO UPDATE SET
+     name = excluded.name,
+     role = excluded.role,
+     phone = excluded.phone,
+     email = excluded.email,
+     created_at = excluded.created_at`
+)
+
+const replaceResourceStatement = db.prepare(
+  `INSERT INTO resources (id, title, type, link, owner, notes, created_at)
+   VALUES (?, ?, ?, ?, ?, ?, ?)
+   ON CONFLICT(id) DO UPDATE SET
+     title = excluded.title,
+     type = excluded.type,
+     link = excluded.link,
+     owner = excluded.owner,
+     notes = excluded.notes,
+     created_at = excluded.created_at`
+)
+
+const replaceSupportDeskStatement = db.prepare(
+  `INSERT INTO support_desks (id, department, phone, email, hours, notes, created_at)
+   VALUES (?, ?, ?, ?, ?, ?, ?)
+   ON CONFLICT(id) DO UPDATE SET
+     department = excluded.department,
+     phone = excluded.phone,
+     email = excluded.email,
+     hours = excluded.hours,
+     notes = excluded.notes,
+     created_at = excluded.created_at`
+)
+
+const clearTableStatements = {
+  cases: db.prepare('DELETE FROM cases'),
+  clients: db.prepare('DELETE FROM clients'),
+  tasks: db.prepare('DELETE FROM tasks'),
+  team: db.prepare('DELETE FROM team_members'),
+  resources: db.prepare('DELETE FROM resources'),
+  supportDesks: db.prepare('DELETE FROM support_desks'),
+}
+
+const replacePortalDataTransaction = db.transaction((payload) => {
+  const stats = normaliseStatsInput(payload.stats)
+  for (const key of STAT_KEYS) {
+    replaceStatsStatement.run(key, stats[key])
+  }
+
+  clearTableStatements.cases.run()
+  for (const item of toArray(payload.cases).map(normaliseCaseInput).filter((item) => item.caseNumber && item.client)) {
+    replaceCaseStatement.run(
+      item.id,
+      item.caseNumber,
+      item.client,
+      item.opponent,
+      item.practiceArea,
+      item.nextDate,
+      item.status,
+      item.courtroom,
+      item.notes,
+      item.createdAt
+    )
+  }
+
+  clearTableStatements.clients.run()
+  for (const item of toArray(payload.clients)
+    .map(normaliseClientInput)
+    .filter((item) => item.organisation)) {
+    replaceClientStatement.run(
+      item.id,
+      item.organisation,
+      item.primaryContact,
+      item.email,
+      item.phone,
+      item.address,
+      item.notes,
+      item.createdAt
+    )
+  }
+
+  clearTableStatements.tasks.run()
+  for (const item of toArray(payload.tasks).map(normaliseTaskInput).filter((item) => item.title && item.owner && item.due)) {
+    replaceTaskStatement.run(item.id, item.title, item.owner, item.due, item.createdAt)
+  }
+
+  clearTableStatements.team.run()
+  for (const item of toArray(payload.team).map(normaliseTeamInput).filter((item) => item.name && item.role)) {
+    replaceTeamStatement.run(item.id, item.name, item.role, item.phone, item.email, item.createdAt)
+  }
+
+  clearTableStatements.resources.run()
+  for (const item of toArray(payload.resources).map(normaliseResourceInput).filter((item) => item.title)) {
+    replaceResourceStatement.run(
+      item.id,
+      item.title,
+      item.type,
+      item.link,
+      item.owner,
+      item.notes,
+      item.createdAt
+    )
+  }
+
+  clearTableStatements.supportDesks.run()
+  for (const item of toArray(payload.supportDesks).map(normaliseSupportDeskInput).filter((item) => item.department)) {
+    replaceSupportDeskStatement.run(
+      item.id,
+      item.department,
+      item.phone,
+      item.email,
+      item.hours,
+      item.notes,
+      item.createdAt
+    )
+  }
+})
+
+export const replacePortalData = (payload = {}) => {
+  replacePortalDataTransaction(payload)
+  return getPortalData()
+}
+
+const insertStatements = {
+  cases: db.prepare(
+    `INSERT INTO cases (id, case_number, client, opponent, practice_area, next_date, status, courtroom, notes)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ),
+  clients: db.prepare(
+    `INSERT INTO clients (id, organisation, primary_contact, email, phone, address, notes)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  ),
+  tasks: db.prepare('INSERT INTO tasks (id, title, owner, due) VALUES (?, ?, ?, ?)'),
+  team: db.prepare('INSERT INTO team_members (id, name, role, phone, email) VALUES (?, ?, ?, ?, ?)'),
+  resources: db.prepare(
+    'INSERT INTO resources (id, title, type, link, owner, notes) VALUES (?, ?, ?, ?, ?, ?)'
+  ),
+  supportDesks: db.prepare(
+    'INSERT INTO support_desks (id, department, phone, email, hours, notes) VALUES (?, ?, ?, ?, ?, ?)'
+  ),
+}
+
+const deleteStatements = {
+  cases: db.prepare('DELETE FROM cases WHERE id = ?'),
+  clients: db.prepare('DELETE FROM clients WHERE id = ?'),
+  tasks: db.prepare('DELETE FROM tasks WHERE id = ?'),
+  team: db.prepare('DELETE FROM team_members WHERE id = ?'),
+  resources: db.prepare('DELETE FROM resources WHERE id = ?'),
+  supportDesks: db.prepare('DELETE FROM support_desks WHERE id = ?'),
+}
+
+const newId = () => randomUUID()
+
+const numberOrZero = (value) => {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+const normaliseOptional = (value) => {
+  if (value === null || value === undefined) return null
+  const trimmed = String(value).trim()
+  return trimmed.length ? trimmed : null
+}
+
+const ensureTimestamp = (value) => {
+  if (!value) return new Date().toISOString()
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? new Date().toISOString() : date.toISOString()
+}
+
+const ensureId = (value) => {
+  const trimmed = typeof value === 'string' ? value.trim() : ''
+  return trimmed || newId()
+}
+
+const normaliseStatsInput = (value = {}) => {
+  const stats = {}
+  for (const key of STAT_KEYS) {
+    stats[key] = numberOrZero(value[key])
+  }
+  return stats
+}
+
+const normaliseCaseInput = (value = {}) => ({
+  id: ensureId(value.id),
+  caseNumber: String(value.caseNumber || value.case_number || '').trim(),
+  client: String(value.client || '').trim(),
+  opponent: normaliseOptional(value.opponent || value.opponent_name),
+  practiceArea: normaliseOptional(value.practiceArea || value.practice_area),
+  nextDate: normaliseOptional(value.nextDate || value.next_date),
+  status: normaliseOptional(value.status),
+  courtroom: normaliseOptional(value.courtroom),
+  notes: normaliseOptional(value.notes),
+  createdAt: ensureTimestamp(value.createdAt || value.created_at),
+})
+
+const normaliseClientInput = (value = {}) => ({
+  id: ensureId(value.id),
+  organisation: String(value.organisation || value.name || '').trim(),
+  primaryContact: normaliseOptional(value.primaryContact || value.primary_contact),
+  email: normaliseOptional(value.email),
+  phone: normaliseOptional(value.phone),
+  address: normaliseOptional(value.address),
+  notes: normaliseOptional(value.notes),
+  createdAt: ensureTimestamp(value.createdAt || value.created_at),
+})
+
+const normaliseTaskInput = (value = {}) => ({
+  id: ensureId(value.id),
+  title: String(value.title || '').trim(),
+  owner: String(value.owner || '').trim(),
+  due: normaliseOptional(value.due),
+  createdAt: ensureTimestamp(value.createdAt || value.created_at),
+})
+
+const normaliseTeamInput = (value = {}) => ({
+  id: ensureId(value.id),
+  name: String(value.name || '').trim(),
+  role: String(value.role || '').trim(),
+  phone: normaliseOptional(value.phone),
+  email: normaliseOptional(value.email),
+  createdAt: ensureTimestamp(value.createdAt || value.created_at),
+})
+
+const normaliseResourceInput = (value = {}) => ({
+  id: ensureId(value.id),
+  title: String(value.title || '').trim(),
+  type: normaliseOptional(value.type),
+  link: normaliseOptional(value.link),
+  owner: normaliseOptional(value.owner),
+  notes: normaliseOptional(value.notes),
+  createdAt: ensureTimestamp(value.createdAt || value.created_at),
+})
+
+const normaliseSupportDeskInput = (value = {}) => ({
+  id: ensureId(value.id),
+  department: String(value.department || '').trim(),
+  phone: normaliseOptional(value.phone),
+  email: normaliseOptional(value.email),
+  hours: normaliseOptional(value.hours),
+  notes: normaliseOptional(value.notes),
+  createdAt: ensureTimestamp(value.createdAt || value.created_at),
+})
+
+const toArray = (value) => (Array.isArray(value) ? value : [])
+
+export const createCase = (payload) => {
+  const id = newId()
+  insertStatements.cases.run(
+    id,
+    payload.caseNumber,
+    payload.client,
+    payload.opponent || null,
+    payload.practiceArea || null,
+    payload.nextDate || null,
+    payload.status || null,
+    payload.courtroom || null,
+    payload.notes || null
+  )
+  const row = db.prepare('SELECT * FROM cases WHERE id = ?').get(id)
+  return mapCase(row)
+}
+
+export const removeCase = (id) => {
+  deleteStatements.cases.run(id)
+}
+
+export const createClient = (payload) => {
+  const id = newId()
+  insertStatements.clients.run(
+    id,
+    payload.organisation,
+    payload.primaryContact || null,
+    payload.email || null,
+    payload.phone || null,
+    payload.address || null,
+    payload.notes || null
+  )
+  const row = db.prepare('SELECT * FROM clients WHERE id = ?').get(id)
+  return mapClient(row)
+}
+
+export const removeClient = (id) => {
+  deleteStatements.clients.run(id)
+}
+
+export const createTask = (payload) => {
+  const id = newId()
+  insertStatements.tasks.run(id, payload.title, payload.owner, payload.due)
+  const row = db.prepare('SELECT * FROM tasks WHERE id = ?').get(id)
+  return mapTask(row)
+}
+
+export const removeTask = (id) => {
+  deleteStatements.tasks.run(id)
+}
+
+export const createTeamMember = (payload) => {
+  const id = newId()
+  insertStatements.team.run(id, payload.name, payload.role, payload.phone || null, payload.email || null)
+  const row = db.prepare('SELECT * FROM team_members WHERE id = ?').get(id)
+  return mapTeamMember(row)
+}
+
+export const removeTeamMember = (id) => {
+  deleteStatements.team.run(id)
+}
+
+export const createResource = (payload) => {
+  const id = newId()
+  insertStatements.resources.run(
+    id,
+    payload.title,
+    payload.type || null,
+    payload.link || null,
+    payload.owner || null,
+    payload.notes || null
+  )
+  const row = db.prepare('SELECT * FROM resources WHERE id = ?').get(id)
+  return mapResource(row)
+}
+
+export const removeResource = (id) => {
+  deleteStatements.resources.run(id)
+}
+
+export const createSupportDesk = (payload) => {
+  const id = newId()
+  insertStatements.supportDesks.run(
+    id,
+    payload.department,
+    payload.phone || null,
+    payload.email || null,
+    payload.hours || null,
+    payload.notes || null
+  )
+  const row = db.prepare('SELECT * FROM support_desks WHERE id = ?').get(id)
+  return mapSupportDesk(row)
+}
+
+export const removeSupportDesk = (id) => {
+  deleteStatements.supportDesks.run(id)
+}
+
+export const verifyPassword = (storedHash, input) => {
+  if (!storedHash || !input) return false
+  const [saltHex, hashHex] = storedHash.split(':')
+  if (!saltHex || !hashHex) return false
+  try {
+    const inputBuffer = scryptSync(input, Buffer.from(saltHex, 'hex'), 64)
+    const storedBuffer = Buffer.from(hashHex, 'hex')
+    return timingSafeEqual(inputBuffer, storedBuffer)
+  } catch (error) {
+    console.error('Failed to verify password', error)
+    return false
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,0 +1,8 @@
+import { config } from './config.js'
+import { createServer } from './server.js'
+
+const app = createServer()
+
+app.listen(config.port, () => {
+  console.log(`Pasha Law Senate API listening on port ${config.port}`)
+})

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,0 +1,278 @@
+import express from 'express'
+import cors from 'cors'
+import helmet from 'helmet'
+import { config } from './config.js'
+import {
+  seedDefaults,
+  findUserByEmail,
+  createUser,
+  verifyPassword,
+  createSession,
+  getPortalData,
+  updateStats,
+  createCase,
+  removeCase,
+  createClient,
+  removeClient,
+  createTask,
+  removeTask,
+  createTeamMember,
+  removeTeamMember,
+  createResource,
+  removeResource,
+  createSupportDesk,
+  removeSupportDesk,
+  replacePortalData,
+} from './database.js'
+
+seedDefaults()
+
+const app = express()
+
+app.use(helmet())
+
+const allowedOrigins = config.clientOrigins
+const allowAnyOrigin = config.allowAnyOrigin
+
+app.use(
+  cors({
+    origin(origin, callback) {
+      if (!origin) {
+        return callback(null, true)
+      }
+
+      if (allowAnyOrigin) {
+        return callback(null, true)
+      }
+
+      const normalisedOrigin = origin.replace(/\/$/, '')
+      if (allowedOrigins.includes(normalisedOrigin)) {
+        return callback(null, true)
+      }
+
+      return callback(new Error(`Origin ${origin} is not allowed by CORS.`))
+    },
+    credentials: false,
+  })
+)
+app.use(express.json())
+
+const asyncHandler = (handler) => (req, res, next) => {
+  Promise.resolve(handler(req, res, next)).catch(next)
+}
+
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok', timestamp: new Date().toISOString() })
+})
+
+app.post(
+  '/api/auth/login',
+  asyncHandler((req, res) => {
+    const { email, password } = req.body || {}
+    if (!email || !password) {
+      return res.status(400).json({ message: 'Email and password are required.' })
+    }
+
+    const user = findUserByEmail(String(email).toLowerCase())
+    if (!user || !verifyPassword(user.password_hash, password)) {
+      return res.status(401).json({ message: 'Invalid credentials.' })
+    }
+
+    const session = createSession(user.id)
+
+    res.json({
+      token: session.token,
+      user: { id: user.id, email: user.email, name: user.name },
+      expiresAt: session.expiresAt,
+    })
+  })
+)
+
+app.post(
+  '/api/auth/register',
+  asyncHandler((req, res) => {
+    const { email, password, name } = req.body || {}
+    const trimmedName = typeof name === 'string' ? name.trim() : ''
+    const normalisedEmail = typeof email === 'string' ? email.trim().toLowerCase() : ''
+    if (!trimmedName || !normalisedEmail) {
+      return res.status(400).json({ message: 'Name and email are required.' })
+    }
+    if (!password || String(password).length < 8) {
+      return res
+        .status(400)
+        .json({ message: 'Password must be at least 8 characters long.' })
+    }
+
+    try {
+      const user = createUser({ email: normalisedEmail, password, name: trimmedName })
+      const session = createSession(user.id)
+
+      res.status(201).json({
+        token: session.token,
+        user: { id: user.id, email: user.email, name: user.name },
+        expiresAt: session.expiresAt,
+      })
+    } catch (error) {
+      if (error?.code === 'USER_EXISTS') {
+        return res.status(409).json({ message: 'An account with this email already exists.' })
+      }
+      throw error
+    }
+  })
+)
+
+app.get(
+  '/api/portal',
+  asyncHandler((req, res) => {
+    res.json(getPortalData())
+  })
+)
+
+app.put(
+  '/api/portal',
+  asyncHandler((req, res) => {
+    const updated = replacePortalData(req.body || {})
+    res.json(updated)
+  })
+)
+
+app.put(
+  '/api/portal/stats',
+  asyncHandler((req, res) => {
+    const allowedKeys = ['activeMatters', 'hearingsThisWeek', 'filingsPending', 'teamUtilisation']
+    const stats = updateStats(req.body || {})
+    for (const key of Object.keys(stats)) {
+      if (!allowedKeys.includes(key)) {
+        delete stats[key]
+      }
+    }
+    res.json({ stats })
+  })
+)
+
+app.post(
+  '/api/cases',
+  asyncHandler((req, res) => {
+    const { caseNumber, client } = req.body || {}
+    if (!caseNumber || !client) {
+      return res.status(400).json({ message: 'Case number and client are required.' })
+    }
+    const created = createCase(req.body)
+    res.status(201).json(created)
+  })
+)
+
+app.delete(
+  '/api/cases/:id',
+  asyncHandler((req, res) => {
+    removeCase(req.params.id)
+    res.status(204).end()
+  })
+)
+
+app.post(
+  '/api/clients',
+  asyncHandler((req, res) => {
+    const { organisation } = req.body || {}
+    if (!organisation) {
+      return res.status(400).json({ message: 'Organisation name is required.' })
+    }
+    const created = createClient(req.body)
+    res.status(201).json(created)
+  })
+)
+
+app.delete(
+  '/api/clients/:id',
+  asyncHandler((req, res) => {
+    removeClient(req.params.id)
+    res.status(204).end()
+  })
+)
+
+app.post(
+  '/api/tasks',
+  asyncHandler((req, res) => {
+    const { title, owner, due } = req.body || {}
+    if (!title || !owner || !due) {
+      return res.status(400).json({ message: 'Title, owner, and due date are required.' })
+    }
+    const created = createTask(req.body)
+    res.status(201).json(created)
+  })
+)
+
+app.delete(
+  '/api/tasks/:id',
+  asyncHandler((req, res) => {
+    removeTask(req.params.id)
+    res.status(204).end()
+  })
+)
+
+app.post(
+  '/api/team',
+  asyncHandler((req, res) => {
+    const { name, role } = req.body || {}
+    if (!name || !role) {
+      return res.status(400).json({ message: 'Name and role are required.' })
+    }
+    const created = createTeamMember(req.body)
+    res.status(201).json(created)
+  })
+)
+
+app.delete(
+  '/api/team/:id',
+  asyncHandler((req, res) => {
+    removeTeamMember(req.params.id)
+    res.status(204).end()
+  })
+)
+
+app.post(
+  '/api/resources',
+  asyncHandler((req, res) => {
+    const { title } = req.body || {}
+    if (!title) {
+      return res.status(400).json({ message: 'Title is required.' })
+    }
+    const created = createResource(req.body)
+    res.status(201).json(created)
+  })
+)
+
+app.delete(
+  '/api/resources/:id',
+  asyncHandler((req, res) => {
+    removeResource(req.params.id)
+    res.status(204).end()
+  })
+)
+
+app.post(
+  '/api/support-desks',
+  asyncHandler((req, res) => {
+    const { department } = req.body || {}
+    if (!department) {
+      return res.status(400).json({ message: 'Department is required.' })
+    }
+    const created = createSupportDesk(req.body)
+    res.status(201).json(created)
+  })
+)
+
+app.delete(
+  '/api/support-desks/:id',
+  asyncHandler((req, res) => {
+    removeSupportDesk(req.params.id)
+    res.status(204).end()
+  })
+)
+
+app.use((err, req, res, next) => {
+  console.error(err)
+  res.status(500).json({ message: 'An unexpected error occurred.' })
+})
+
+export const createServer = () => app

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,19 +1,27 @@
-import { Routes, Route } from 'react-router-dom'
-import Layout from './components/Layout.jsx'
-import Dashboard from './pages/Dashboard.jsx'
-import Matters from './pages/Matters.jsx'
-import MatterForm from './pages/MatterForm.jsx'
+import { Navigate, Route, Routes } from 'react-router-dom'
+import ShellLayout from './components/ShellLayout.jsx'
+import DashboardPage from './pages/DashboardPage.jsx'
+import CasesPage from './pages/CasesPage.jsx'
+import ClientsPage from './pages/ClientsPage.jsx'
+import UpcomingCasesPage from './pages/UpcomingCasesPage.jsx'
+import ResourcesPage from './pages/ResourcesPage.jsx'
 
-export default function App(){
+export default function App() {
   return (
-    <Layout>
-      <Routes>
-        <Route path="/" element={<Dashboard />} />
-        <Route path="/matters" element={<Matters />} />
-        <Route path="/matters/new" element={<MatterForm />} />
-        <Route path="/matters/:id" element={<MatterForm />} />
-        <Route path="*" element={<div className="p-4">Not Found</div>} />
-      </Routes>
-    </Layout>
+    <Routes>
+      <Route path="/" element={<ShellLayout />}>
+        <Route index element={<Navigate to="/dashboard" replace />} />
+        <Route path="dashboard" element={<DashboardPage />} />
+        <Route path="cases" element={<CasesPage />} />
+        <Route path="clients" element={<ClientsPage />} />
+        <Route path="upcoming" element={<UpcomingCasesPage />} />
+        <Route path="resources" element={<ResourcesPage />} />
+      </Route>
+
+      <Route
+        path="*"
+        element={<Navigate to="/dashboard" replace />}
+      />
+    </Routes>
   )
 }

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -1,50 +1,72 @@
-// src/components/Drawer.jsx
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
+
+const parseWidth = (value) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return { numeric: value, css: `${value}px` }
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed.endsWith('px')) {
+      const numeric = Number.parseFloat(trimmed)
+      if (Number.isFinite(numeric)) {
+        return { numeric, css: trimmed }
+      }
+    }
+
+    const numeric = Number.parseFloat(trimmed)
+    if (Number.isFinite(numeric)) {
+      return { numeric, css: `${numeric}px` }
+    }
+  }
+
+  return { numeric: 420, css: '420px' }
+}
 
 export default function Drawer({ open, onClose, width = 420, children, title, footer }) {
-  // Close on ESC
   useEffect(() => {
-    const onKey = (e) => { if (e.key === 'Escape') onClose?.() }
+    const onKey = (event) => {
+      if (event.key === 'Escape') onClose?.()
+    }
+
     if (open) window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [open, onClose])
 
-  // Dynamic class to control the slide animation
-  const translateClass = open ? 'translate-x-0' : `translate-x-[${width}px]`
-  
+  const resolvedWidth = useMemo(() => parseWidth(width), [width])
+  const panelStyle = useMemo(
+    () => ({
+      width: resolvedWidth.css,
+      transform: `translateX(${open ? 0 : resolvedWidth.numeric}px)`,
+    }),
+    [open, resolvedWidth]
+  )
+
   return (
     <>
-      {/* Backdrop */}
       <div
-        className={`fixed inset-0 z-40 bg-black/40 transition-opacity ${open ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+        className={`fixed inset-0 z-40 bg-black/40 transition-opacity ${
+          open ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
         onClick={onClose}
       />
-      
-      {/* Panel */}
+
       <aside
-        // Use flex-col to stack header, content, and footer
-        className={`fixed right-0 top-0 z-50 h-full max-w-full bg-white dark:bg-slate-900 border-l border-slate-200 dark:border-slate-800 shadow-2xl transition-transform duration-300 ease-out flex flex-col ${translateClass}`}
-        style={{ width: `${width}px` }}
+        className="fixed right-0 top-0 z-50 h-full max-w-full bg-white dark:bg-slate-900 border-l border-slate-200 dark:border-slate-800 shadow-2xl transition-transform duration-300 ease-out flex flex-col"
+        style={panelStyle}
         aria-hidden={!open}
         role="dialog"
       >
-        {/* Header */}
         <header className="px-4 py-3 border-b border-slate-200 dark:border-slate-800 flex items-center justify-between shrink-0">
           <h3 className="font-semibold text-xl">{title}</h3>
-          <button className="btn" onClick={onClose} aria-label="Close">✕</button>
+          <button className="btn" onClick={onClose} aria-label="Close">
+            ✕
+          </button>
         </header>
 
-        {/* Content Area */}
-        <div className="flex-1 overflow-y-auto p-4">
-          {children}
-        </div>
+        <div className="flex-1 overflow-y-auto p-4">{children}</div>
 
-        {/* Footer */}
-        {footer && (
-          <footer className="px-4 py-3 border-t border-slate-200 dark:border-slate-800 shrink-0">
-            {footer}
-          </footer>
-        )}
+        {footer && <footer className="px-4 py-3 border-t border-slate-200 dark:border-slate-800 shrink-0">{footer}</footer>}
       </aside>
     </>
   )

--- a/src/components/ShellLayout.jsx
+++ b/src/components/ShellLayout.jsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from 'react'
+import { Link, NavLink, Outlet } from 'react-router-dom'
+import { Menu, X } from 'lucide-react'
+import { usePortalData } from '../store/portalData'
+
+const navItems = [
+  { to: '/dashboard', label: 'Overview' },
+  { to: '/cases', label: 'Cases' },
+  { to: '/clients', label: 'Clients' },
+  { to: '/upcoming', label: 'Upcoming Hearings' },
+  { to: '/resources', label: 'Resources' },
+]
+
+export default function ShellLayout() {
+  const [mobileOpen, setMobileOpen] = useState(false)
+  const load = usePortalData((state) => state.load)
+  const hasLoaded = usePortalData((state) => state.hasLoaded)
+  const isLoading = usePortalData((state) => state.isLoading)
+  const error = usePortalData((state) => state.error)
+  const clearError = usePortalData((state) => state.clearError)
+  const notice = usePortalData((state) => state.notice)
+  const clearNotice = usePortalData((state) => state.clearNotice)
+  const hasCache = usePortalData((state) => state.hasCache)
+
+  useEffect(() => {
+    if (!hasLoaded && !isLoading) {
+      load().catch(() => {})
+    }
+  }, [hasLoaded, isLoading, load])
+
+  const handleRetry = () => {
+    clearError()
+    load().catch(() => {})
+  }
+
+  const renderContent = () => {
+    if (!hasLoaded) {
+      if (hasCache) {
+        return <Outlet />
+      }
+      if (isLoading) {
+        return (
+          <div className="card p-6 text-sm text-slate-500">Loading the latest portal data…</div>
+        )
+      }
+      return (
+        <div className="card p-6 space-y-3 text-sm">
+          <p className="font-medium text-red-600">{error || 'Unable to load portal data.'}</p>
+          <button type="button" className="btn btn-primary" onClick={handleRetry}>
+            Try again
+          </button>
+        </div>
+      )
+    }
+
+    return <Outlet />
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-100/80 dark:bg-slate-950 text-slate-900 dark:text-slate-100">
+      <header className="border-b border-slate-200/70 dark:border-slate-800/70 bg-white/80 dark:bg-slate-900/80 backdrop-blur">
+        <div className="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <button
+              className="md:hidden btn"
+              onClick={() => setMobileOpen((o) => !o)}
+              aria-label="Toggle navigation"
+            >
+              {mobileOpen ? <X size={18} /> : <Menu size={18} />}
+            </button>
+            <Link to="/dashboard" className="text-lg font-semibold tracking-tight">
+              Pasha Law Senate
+            </Link>
+          </div>
+          <div className="hidden md:flex items-center gap-6 text-sm font-medium">
+            {navItems.map((item) => (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                className={({ isActive }) =>
+                  `hover:text-brand-600 transition ${isActive ? 'text-brand-600' : 'text-slate-600 dark:text-slate-300'}`
+                }
+              >
+                {item.label}
+              </NavLink>
+            ))}
+          </div>
+        </div>
+        {mobileOpen && (
+          <nav className="md:hidden border-t border-slate-200/70 dark:border-slate-800/70 bg-white dark:bg-slate-900">
+            <ul className="px-4 py-3 space-y-2">
+              {navItems.map((item) => (
+                <li key={item.to}>
+                  <NavLink
+                    to={item.to}
+                    onClick={() => setMobileOpen(false)}
+                    className={({ isActive }) =>
+                      `block rounded-lg px-3 py-2 text-sm font-medium ${
+                        isActive ? 'bg-brand-600/10 text-brand-700 dark:text-brand-300' : 'text-slate-700 dark:text-slate-200'
+                      }`
+                    }
+                  >
+                    {item.label}
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        )}
+      </header>
+
+      <main className="max-w-6xl mx-auto px-4 py-10 space-y-4">
+        {error && hasLoaded && (
+          <div className="rounded-2xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700 flex items-start justify-between gap-4">
+            <span>{error}</span>
+            <button type="button" className="text-xs font-medium underline" onClick={clearError}>
+              Dismiss
+            </button>
+          </div>
+        )}
+        {notice && (
+          <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 flex items-start justify-between gap-4">
+            <span>{notice}</span>
+            <button type="button" className="text-xs font-medium underline" onClick={clearNotice}>
+              Dismiss
+            </button>
+          </div>
+        )}
+        {renderContent()}
+      </main>
+    </div>
+  )
+}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,5 +1,158 @@
-import { API_BASE } from '../config'
-export async function listCases(){ const r = await fetch(`${API_BASE}/cases`); return r.json() }
-export async function createCase(body){ const r = await fetch(`${API_BASE}/cases`, { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(body) }); return r.json() }
-export async function updateCase(id, body){ const r = await fetch(`${API_BASE}/cases/${id}`, { method:'PUT', headers:{'Content-Type':'application/json'}, body:JSON.stringify(body) }); return r.json() }
-export async function deleteCase(id){ await fetch(`${API_BASE}/cases/${id}`, { method:'DELETE' }) }
+const resolveBaseUrl = () => {
+  const configured = import.meta.env.VITE_API_BASE_URL?.trim()
+  if (configured) {
+    return configured.replace(/\/$/, '')
+  }
+
+  if (typeof window === 'undefined') {
+    return 'http://localhost:4000'
+  }
+
+  const { protocol, hostname, port } = window.location
+  const isLocalhost = ['localhost', '127.0.0.1', '::1'].includes(hostname)
+
+  if (isLocalhost && port && port !== '4000') {
+    return `${protocol}//${hostname}:4000`
+  }
+
+  return ''
+}
+
+const API_BASE_URL = resolveBaseUrl()
+
+const parseResponse = async (response) => {
+  const contentType = response.headers.get('content-type') || ''
+  const isJson = contentType.includes('application/json')
+  const hasBody = ![204, 205].includes(response.status)
+  let body = null
+
+  if (hasBody && isJson) {
+    body = await response.json()
+  }
+
+  if (!response.ok) {
+    if (!isJson) {
+      const offlineError = new Error('Portal server is unavailable. Running in offline mode.')
+      offlineError.status = response.status
+      offlineError.code = 'API_UNAVAILABLE'
+      offlineError.body = null
+      throw offlineError
+    }
+
+    const message = body?.message || 'Request failed'
+    const error = new Error(message)
+    error.status = response.status
+    error.body = body
+    throw error
+  }
+
+  return body
+}
+
+const request = async (path, options = {}) => {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('ad-token') : null
+  const headers = new Headers(options.headers || {})
+  if (!headers.has('Content-Type') && options.body && !(options.body instanceof FormData)) {
+    headers.set('Content-Type', 'application/json')
+  }
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`)
+  }
+
+  const url = `${API_BASE_URL}${path}`
+  try {
+    const response = await fetch(url, {
+      ...options,
+      headers,
+    })
+    return parseResponse(response)
+  } catch (error) {
+    const networkError = new Error('Unable to reach the server. Please try again.')
+    networkError.cause = error
+    networkError.url = url
+    throw networkError
+  }
+}
+
+export const api = {
+  register: (payload) =>
+    request('/api/auth/register', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }),
+  login: (credentials) =>
+    request('/api/auth/login', {
+      method: 'POST',
+      body: JSON.stringify(credentials),
+    }),
+  logout: () =>
+    request('/api/auth/logout', {
+      method: 'POST',
+    }),
+  getSession: () => request('/api/auth/session'),
+  getPortal: () => request('/api/portal'),
+  savePortal: (payload) =>
+    request('/api/portal', {
+      method: 'PUT',
+      body: JSON.stringify(payload),
+    }),
+  updateStats: (stats) =>
+    request('/api/portal/stats', {
+      method: 'PUT',
+      body: JSON.stringify(stats),
+    }),
+  createCase: (payload) =>
+    request('/api/cases', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }),
+  deleteCase: (id) =>
+    request(`/api/cases/${id}`, {
+      method: 'DELETE',
+    }),
+  createClient: (payload) =>
+    request('/api/clients', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }),
+  deleteClient: (id) =>
+    request(`/api/clients/${id}`, {
+      method: 'DELETE',
+    }),
+  createTask: (payload) =>
+    request('/api/tasks', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }),
+  deleteTask: (id) =>
+    request(`/api/tasks/${id}`, {
+      method: 'DELETE',
+    }),
+  createTeamMember: (payload) =>
+    request('/api/team', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }),
+  deleteTeamMember: (id) =>
+    request(`/api/team/${id}`, {
+      method: 'DELETE',
+    }),
+  createResource: (payload) =>
+    request('/api/resources', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }),
+  deleteResource: (id) =>
+    request(`/api/resources/${id}`, {
+      method: 'DELETE',
+    }),
+  createSupportDesk: (payload) =>
+    request('/api/support-desks', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }),
+  deleteSupportDesk: (id) =>
+    request(`/api/support-desks/${id}`, {
+      method: 'DELETE',
+    }),
+}

--- a/src/pages/CasesPage.jsx
+++ b/src/pages/CasesPage.jsx
@@ -1,0 +1,205 @@
+import { useState } from 'react'
+import dayjs from 'dayjs'
+import { usePortalData } from '../store/portalData'
+
+const defaultForm = {
+  caseNumber: '',
+  client: '',
+  opponent: '',
+  practiceArea: '',
+  nextDate: '',
+  status: '',
+  courtroom: '',
+  notes: '',
+}
+
+export default function CasesPage() {
+  const cases = usePortalData((state) => state.data.cases)
+  const addCase = usePortalData((state) => state.addCase)
+  const removeCase = usePortalData((state) => state.removeCase)
+  const [form, setForm] = useState(defaultForm)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [removingId, setRemovingId] = useState(null)
+
+  const handleChange = (event) => {
+    const { name, value } = event.target
+    setForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    if (!form.caseNumber || !form.client) return
+    setIsSubmitting(true)
+    try {
+      await addCase(form)
+      setForm(defaultForm)
+    } catch (error) {
+      console.error('Failed to add case', error)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleRemove = async (id) => {
+    setRemovingId(id)
+    try {
+      await removeCase(id)
+    } catch (error) {
+      console.error('Failed to remove case', error)
+    } finally {
+      setRemovingId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Active case files</h1>
+        <p className="text-sm text-slate-500">Add matters below to build your live case register.</p>
+      </header>
+
+      <section className="card p-6 space-y-4">
+        <h2 className="text-lg font-semibold">Add a matter</h2>
+        <form className="grid gap-4 md:grid-cols-2" onSubmit={handleSubmit}>
+          <label className="space-y-2 text-sm">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Case number</span>
+            <input
+              name="caseNumber"
+              className="input"
+              value={form.caseNumber}
+              onChange={handleChange}
+              placeholder="e.g. CIV/2381/2024"
+              required
+            />
+          </label>
+          <label className="space-y-2 text-sm">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Client</span>
+            <input
+              name="client"
+              className="input"
+              value={form.client}
+              onChange={handleChange}
+              placeholder="Client name"
+              required
+            />
+          </label>
+          <label className="space-y-2 text-sm">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Opponent</span>
+            <input
+              name="opponent"
+              className="input"
+              value={form.opponent}
+              onChange={handleChange}
+              placeholder="Opposing party"
+            />
+          </label>
+          <label className="space-y-2 text-sm">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Practice area</span>
+            <input
+              name="practiceArea"
+              className="input"
+              value={form.practiceArea}
+              onChange={handleChange}
+              placeholder="Commercial dispute"
+            />
+          </label>
+          <label className="space-y-2 text-sm">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Next hearing</span>
+            <input
+              type="date"
+              name="nextDate"
+              className="input"
+              value={form.nextDate}
+              onChange={handleChange}
+            />
+          </label>
+          <label className="space-y-2 text-sm">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Status</span>
+            <input
+              name="status"
+              className="input"
+              value={form.status}
+              onChange={handleChange}
+              placeholder="Awaiting filing"
+            />
+          </label>
+          <label className="space-y-2 text-sm">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Courtroom</span>
+            <input
+              name="courtroom"
+              className="input"
+              value={form.courtroom}
+              onChange={handleChange}
+              placeholder="Court details"
+            />
+          </label>
+          <label className="space-y-2 text-sm md:col-span-2">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Notes</span>
+            <textarea
+              name="notes"
+              className="input min-h-[90px]"
+              value={form.notes}
+              onChange={handleChange}
+              placeholder="Preparation steps, evidence reminders, or links"
+            />
+          </label>
+          <div className="md:col-span-2 flex justify-end">
+            <button type="submit" className="btn btn-primary" disabled={isSubmitting}>
+              {isSubmitting ? 'Adding…' : 'Add matter'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <div className="card overflow-hidden">
+        <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800 text-sm">
+          <thead className="bg-slate-50/70 dark:bg-slate-900/70 text-left text-xs font-semibold uppercase tracking-wider">
+            <tr>
+              <th className="px-4 py-3">Case number</th>
+              <th className="px-4 py-3">Client</th>
+              <th className="px-4 py-3">Opponent</th>
+              <th className="px-4 py-3">Practice area</th>
+              <th className="px-4 py-3">Next hearing</th>
+              <th className="px-4 py-3">Status</th>
+              <th className="px-4 py-3 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100 dark:divide-slate-800 bg-white/60 dark:bg-slate-950/50">
+            {cases.length === 0 ? (
+              <tr>
+                <td className="px-4 py-6 text-center text-slate-500" colSpan={7}>
+                  No cases have been added yet.
+                </td>
+              </tr>
+            ) : (
+              cases.map((item) => (
+                <tr key={item.id} className="hover:bg-brand-50/50 dark:hover:bg-slate-800/60">
+                  <td className="px-4 py-4 font-medium text-brand-700 dark:text-brand-200">{item.caseNumber}</td>
+                  <td className="px-4 py-4">{item.client}</td>
+                  <td className="px-4 py-4">{item.opponent || '—'}</td>
+                  <td className="px-4 py-4">
+                    {item.practiceArea ? <span className="badge">{item.practiceArea}</span> : '—'}
+                  </td>
+                  <td className="px-4 py-4">
+                    {item.nextDate ? dayjs(item.nextDate).format('DD MMM YYYY') : '—'}
+                  </td>
+                  <td className="px-4 py-4 text-slate-600 dark:text-slate-300">{item.status || '—'}</td>
+                  <td className="px-4 py-4 text-right">
+                    <button
+                      type="button"
+                      onClick={() => handleRemove(item.id)}
+                      className="text-xs text-red-500 hover:text-red-600"
+                      disabled={removingId === item.id}
+                    >
+                      {removingId === item.id ? 'Removing…' : 'Remove'}
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/ClientsPage.jsx
+++ b/src/pages/ClientsPage.jsx
@@ -1,0 +1,166 @@
+import { useState } from 'react'
+import { usePortalData } from '../store/portalData'
+
+const defaultForm = {
+  organisation: '',
+  primaryContact: '',
+  phone: '',
+  email: '',
+  address: '',
+  notes: '',
+}
+
+export default function ClientsPage() {
+  const clients = usePortalData((state) => state.data.clients)
+  const addClient = usePortalData((state) => state.addClient)
+  const removeClient = usePortalData((state) => state.removeClient)
+  const [form, setForm] = useState(defaultForm)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [removingId, setRemovingId] = useState(null)
+
+  const handleChange = (event) => {
+    const { name, value } = event.target
+    setForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    if (!form.organisation) return
+    setIsSubmitting(true)
+    try {
+      await addClient(form)
+      setForm(defaultForm)
+    } catch (error) {
+      console.error('Failed to add client', error)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleRemove = async (id) => {
+    setRemovingId(id)
+    try {
+      await removeClient(id)
+    } catch (error) {
+      console.error('Failed to remove client', error)
+    } finally {
+      setRemovingId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Client directory</h1>
+        <p className="text-sm text-slate-500">Capture the details of everyone you represent.</p>
+      </header>
+
+      <section className="card p-6 space-y-4">
+        <h2 className="text-lg font-semibold">Add a client</h2>
+        <form className="grid gap-4 md:grid-cols-2" onSubmit={handleSubmit}>
+          <label className="space-y-2 text-sm">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Client name</span>
+            <input
+              name="organisation"
+              className="input"
+              value={form.organisation}
+              onChange={handleChange}
+              placeholder="Organisation or individual"
+              required
+            />
+          </label>
+          <label className="space-y-2 text-sm">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Primary contact</span>
+            <input
+              name="primaryContact"
+              className="input"
+              value={form.primaryContact}
+              onChange={handleChange}
+              placeholder="Contact person"
+            />
+          </label>
+          <label className="space-y-2 text-sm">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Phone</span>
+            <input
+              name="phone"
+              className="input"
+              value={form.phone}
+              onChange={handleChange}
+              placeholder="Contact number"
+            />
+          </label>
+          <label className="space-y-2 text-sm">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Email</span>
+            <input
+              type="email"
+              name="email"
+              className="input"
+              value={form.email}
+              onChange={handleChange}
+              placeholder="contact@client.com"
+            />
+          </label>
+          <label className="space-y-2 text-sm md:col-span-2">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Address</span>
+            <input
+              name="address"
+              className="input"
+              value={form.address}
+              onChange={handleChange}
+              placeholder="Mailing address"
+            />
+          </label>
+          <label className="space-y-2 text-sm md:col-span-2">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Notes</span>
+            <textarea
+              name="notes"
+              className="input min-h-[90px]"
+              value={form.notes}
+              onChange={handleChange}
+              placeholder="Engagement notes, billing cycles, or reminders"
+            />
+          </label>
+          <div className="md:col-span-2 flex justify-end">
+            <button type="submit" className="btn btn-primary" disabled={isSubmitting}>
+              {isSubmitting ? 'Adding…' : 'Add client'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {clients.length === 0 ? (
+          <p className="card p-5 text-sm text-slate-500">No clients recorded yet.</p>
+        ) : (
+          clients.map((client) => (
+            <article key={client.id} className="card p-5 space-y-2">
+              <header className="flex items-start justify-between gap-3">
+                <div>
+                  <h2 className="text-lg font-semibold text-slate-900 dark:text-white">{client.organisation}</h2>
+                  {client.primaryContact && (
+                    <p className="text-sm text-slate-500">Primary contact: {client.primaryContact}</p>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleRemove(client.id)}
+                  className="text-xs text-red-500 hover:text-red-600"
+                  disabled={removingId === client.id}
+                >
+                  {removingId === client.id ? 'Removing…' : 'Remove'}
+                </button>
+              </header>
+              <div className="text-sm text-slate-600 dark:text-slate-300 space-y-1">
+                {client.phone && <p>{client.phone}</p>}
+                {client.email && <p>{client.email}</p>}
+                {client.address && <p>{client.address}</p>}
+              </div>
+              {client.notes && <p className="text-sm text-slate-500">{client.notes}</p>}
+              <button className="btn btn-primary text-sm" type="button">Open engagement</button>
+            </article>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,0 +1,396 @@
+import { useEffect, useMemo, useState } from 'react'
+import dayjs from 'dayjs'
+import { usePortalData } from '../store/portalData'
+
+const statCards = [
+  { label: 'Active Matters', key: 'activeMatters' },
+  { label: 'Hearings This Week', key: 'hearingsThisWeek' },
+  { label: 'Filings Pending', key: 'filingsPending' },
+  { label: 'Team Utilisation', key: 'teamUtilisation', suffix: '%' },
+]
+
+const defaultStatForm = {
+  activeMatters: '',
+  hearingsThisWeek: '',
+  filingsPending: '',
+  teamUtilisation: '',
+}
+
+const defaultTaskForm = {
+  title: '',
+  owner: '',
+  due: '',
+}
+
+const defaultTeamForm = {
+  name: '',
+  role: '',
+  phone: '',
+  email: '',
+}
+
+export default function DashboardPage() {
+  const stats = usePortalData((state) => state.data.stats)
+  const cases = usePortalData((state) => state.data.cases)
+  const tasks = usePortalData((state) => state.data.tasks)
+  const team = usePortalData((state) => state.data.team)
+  const updateStats = usePortalData((state) => state.updateStats)
+  const addTask = usePortalData((state) => state.addTask)
+  const removeTask = usePortalData((state) => state.removeTask)
+  const addTeamMember = usePortalData((state) => state.addTeamMember)
+  const removeTeamMember = usePortalData((state) => state.removeTeamMember)
+
+  const [statForm, setStatForm] = useState(defaultStatForm)
+  const [taskForm, setTaskForm] = useState(defaultTaskForm)
+  const [teamForm, setTeamForm] = useState(defaultTeamForm)
+  const [isSavingStats, setIsSavingStats] = useState(false)
+  const [isSavingTask, setIsSavingTask] = useState(false)
+  const [isSavingTeam, setIsSavingTeam] = useState(false)
+  const [removingTaskId, setRemovingTaskId] = useState(null)
+  const [removingTeamId, setRemovingTeamId] = useState(null)
+
+  useEffect(() => {
+    setStatForm({
+      activeMatters: stats.activeMatters ?? '',
+      hearingsThisWeek: stats.hearingsThisWeek ?? '',
+      filingsPending: stats.filingsPending ?? '',
+      teamUtilisation: stats.teamUtilisation ?? '',
+    })
+  }, [stats])
+
+  const upcomingCases = useMemo(() => {
+    return cases
+      .filter((item) => item.nextDate)
+      .slice()
+      .sort((a, b) => new Date(a.nextDate) - new Date(b.nextDate))
+      .slice(0, 5)
+  }, [cases])
+
+  const handleStatChange = (event) => {
+    const { name, value } = event.target
+    setStatForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleStatsSubmit = async (event) => {
+    event.preventDefault()
+    setIsSavingStats(true)
+    try {
+      await updateStats({
+        activeMatters: Number(statForm.activeMatters) || 0,
+        hearingsThisWeek: Number(statForm.hearingsThisWeek) || 0,
+        filingsPending: Number(statForm.filingsPending) || 0,
+        teamUtilisation: Number(statForm.teamUtilisation) || 0,
+      })
+    } catch (error) {
+      console.error('Failed to update metrics', error)
+    } finally {
+      setIsSavingStats(false)
+    }
+  }
+
+  const handleTaskChange = (event) => {
+    const { name, value } = event.target
+    setTaskForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleTaskSubmit = async (event) => {
+    event.preventDefault()
+    if (!taskForm.title || !taskForm.owner || !taskForm.due) return
+    setIsSavingTask(true)
+    try {
+      await addTask(taskForm)
+      setTaskForm(defaultTaskForm)
+    } catch (error) {
+      console.error('Failed to add task', error)
+    } finally {
+      setIsSavingTask(false)
+    }
+  }
+
+  const handleTeamChange = (event) => {
+    const { name, value } = event.target
+    setTeamForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleTeamSubmit = async (event) => {
+    event.preventDefault()
+    if (!teamForm.name || !teamForm.role) return
+    setIsSavingTeam(true)
+    try {
+      await addTeamMember(teamForm)
+      setTeamForm(defaultTeamForm)
+    } catch (error) {
+      console.error('Failed to add team member', error)
+    } finally {
+      setIsSavingTeam(false)
+    }
+  }
+
+  const handleTaskRemove = async (id) => {
+    setRemovingTaskId(id)
+    try {
+      await removeTask(id)
+    } catch (error) {
+      console.error('Failed to remove task', error)
+    } finally {
+      setRemovingTaskId(null)
+    }
+  }
+
+  const handleTeamRemove = async (id) => {
+    setRemovingTeamId(id)
+    try {
+      await removeTeamMember(id)
+    } catch (error) {
+      console.error('Failed to remove team member', error)
+    } finally {
+      setRemovingTeamId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {statCards.map((card) => (
+          <article key={card.key} className="card p-5">
+            <p className="text-xs uppercase tracking-wide text-slate-500">{card.label}</p>
+            <p className="mt-3 text-3xl font-semibold text-slate-900 dark:text-white">
+              {stats[card.key] ?? 0}
+              {card.suffix ?? ''}
+            </p>
+          </article>
+        ))}
+      </section>
+
+      <section className="card p-6 space-y-4">
+        <header className="space-y-1">
+          <h2 className="text-lg font-semibold">Update dashboard metrics</h2>
+          <p className="text-sm text-slate-500">
+            Keep your core KPIs current so that everyone sees the latest workload snapshot.
+          </p>
+        </header>
+        <form className="grid gap-4 md:grid-cols-2 lg:grid-cols-4" onSubmit={handleStatsSubmit}>
+          {statCards.map((card) => (
+            <label key={card.key} className="space-y-2 text-sm">
+              <span className="block font-medium text-slate-600 dark:text-slate-300">{card.label}</span>
+              <input
+                type="number"
+                name={card.key}
+                className="input"
+                value={statForm[card.key]}
+                onChange={handleStatChange}
+                min="0"
+              />
+            </label>
+          ))}
+          <div className="md:col-span-2 lg:col-span-4 flex justify-end">
+            <button type="submit" className="btn btn-primary" disabled={isSavingStats}>
+              {isSavingStats ? 'Saving…' : 'Save metrics'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-3">
+        <article className="card p-5 lg:col-span-2 space-y-4">
+          <header className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold">Priority hearings</h2>
+              <p className="text-sm text-slate-500">Add case files with upcoming dates to see them here automatically.</p>
+            </div>
+          </header>
+          <div className="space-y-4">
+            {upcomingCases.length === 0 ? (
+              <p className="text-sm text-slate-500">No hearings tracked yet. Add matters from the Cases page to populate this list.</p>
+            ) : (
+              upcomingCases.map((item) => (
+                <div key={item.id} className="rounded-2xl border border-slate-200/70 dark:border-slate-800/70 p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-brand-600">{item.caseNumber}</p>
+                      <p className="text-base font-medium">{item.client} vs {item.opponent}</p>
+                    </div>
+                    {item.practiceArea && <span className="badge">{item.practiceArea}</span>}
+                  </div>
+                  <dl className="mt-3 grid gap-x-6 gap-y-2 sm:grid-cols-3 text-sm text-slate-600 dark:text-slate-300">
+                    <div>
+                      <dt className="font-medium text-slate-500">Next hearing</dt>
+                      <dd>{dayjs(item.nextDate).format('DD MMM YYYY')}</dd>
+                    </div>
+                    <div>
+                      <dt className="font-medium text-slate-500">Courtroom</dt>
+                      <dd>{item.courtroom || '—'}</dd>
+                    </div>
+                    <div>
+                      <dt className="font-medium text-slate-500">Status</dt>
+                      <dd>{item.status || '—'}</dd>
+                    </div>
+                  </dl>
+                  {item.notes && <p className="mt-3 text-sm text-slate-500">{item.notes}</p>}
+                </div>
+              ))
+            )}
+          </div>
+        </article>
+
+        <aside className="space-y-6">
+          <article className="card p-5 space-y-4">
+            <h2 className="text-lg font-semibold">Action items</h2>
+            <form className="space-y-3" onSubmit={handleTaskSubmit}>
+              <div className="space-y-2 text-sm">
+                <label className="block font-medium text-slate-600 dark:text-slate-300" htmlFor="task-title">Task</label>
+                <input
+                  id="task-title"
+                  name="title"
+                  className="input"
+                  value={taskForm.title}
+                  onChange={handleTaskChange}
+                  placeholder="Draft written submissions"
+                  required
+                />
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2 text-sm">
+                <label className="space-y-2">
+                  <span className="block font-medium text-slate-600 dark:text-slate-300">Owner</span>
+                  <input
+                    name="owner"
+                    className="input"
+                    value={taskForm.owner}
+                    onChange={handleTaskChange}
+                    placeholder="Responsible team member"
+                    required
+                  />
+                </label>
+                <label className="space-y-2">
+                  <span className="block font-medium text-slate-600 dark:text-slate-300">Due date</span>
+                  <input
+                    type="date"
+                    name="due"
+                    className="input"
+                    value={taskForm.due}
+                    onChange={handleTaskChange}
+                    required
+                  />
+                </label>
+              </div>
+              <div className="flex justify-end">
+                <button type="submit" className="btn btn-primary" disabled={isSavingTask}>
+                  {isSavingTask ? 'Adding…' : 'Add task'}
+                </button>
+              </div>
+            </form>
+            <ul className="space-y-3 text-sm">
+              {tasks.length === 0 ? (
+                <li className="text-slate-500">No action items yet.</li>
+              ) : (
+                tasks.map((task) => (
+                  <li key={task.id} className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="font-medium text-slate-900 dark:text-white">{task.title}</p>
+                      <p className="text-xs text-slate-500">
+                        Owner: {task.owner} • Due {dayjs(task.due).format('DD MMM')}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleTaskRemove(task.id)}
+                      className="text-xs text-red-500 hover:text-red-600"
+                      disabled={removingTaskId === task.id}
+                    >
+                      {removingTaskId === task.id ? 'Removing…' : 'Remove'}
+                    </button>
+                  </li>
+                ))
+              )}
+            </ul>
+          </article>
+
+          <article className="card p-5 space-y-4">
+            <h2 className="text-lg font-semibold">Key contacts</h2>
+            <form className="space-y-3" onSubmit={handleTeamSubmit}>
+              <div className="grid gap-3 sm:grid-cols-2 text-sm">
+                <label className="space-y-2">
+                  <span className="block font-medium text-slate-600 dark:text-slate-300">Name</span>
+                  <input
+                    name="name"
+                    className="input"
+                    value={teamForm.name}
+                    onChange={handleTeamChange}
+                    placeholder="Team member"
+                    required
+                  />
+                </label>
+                <label className="space-y-2">
+                  <span className="block font-medium text-slate-600 dark:text-slate-300">Role</span>
+                  <input
+                    name="role"
+                    className="input"
+                    value={teamForm.role}
+                    onChange={handleTeamChange}
+                    placeholder="Designation"
+                    required
+                  />
+                </label>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2 text-sm">
+                <label className="space-y-2">
+                  <span className="block font-medium text-slate-600 dark:text-slate-300">Phone</span>
+                  <input
+                    name="phone"
+                    className="input"
+                    value={teamForm.phone}
+                    onChange={handleTeamChange}
+                    placeholder="Contact number"
+                  />
+                </label>
+                <label className="space-y-2">
+                  <span className="block font-medium text-slate-600 dark:text-slate-300">Email</span>
+                  <input
+                    type="email"
+                    name="email"
+                    className="input"
+                    value={teamForm.email}
+                    onChange={handleTeamChange}
+                    placeholder="name@firm.com"
+                  />
+                </label>
+              </div>
+              <div className="flex justify-end">
+                <button type="submit" className="btn btn-primary" disabled={isSavingTeam}>
+                  {isSavingTeam ? 'Adding…' : 'Add contact'}
+                </button>
+              </div>
+            </form>
+            <ul className="space-y-3 text-sm text-slate-600 dark:text-slate-300">
+              {team.length === 0 ? (
+                <li className="text-slate-500">Add contacts to display them here.</li>
+              ) : (
+                team.map((member) => (
+                  <li
+                    key={member.id}
+                    className="rounded-xl border border-slate-200/70 dark:border-slate-800/70 p-3 flex justify-between gap-3"
+                  >
+                    <div>
+                      <p className="font-semibold text-slate-900 dark:text-white">{member.name}</p>
+                      <p>{member.role}</p>
+                      {member.phone && <p className="text-xs mt-1">{member.phone}</p>}
+                      {member.email && <p className="text-xs">{member.email}</p>}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleTeamRemove(member.id)}
+                      className="text-xs text-red-500 hover:text-red-600"
+                      disabled={removingTeamId === member.id}
+                    >
+                      {removingTeamId === member.id ? 'Removing…' : 'Remove'}
+                    </button>
+                  </li>
+                ))
+              )}
+            </ul>
+          </article>
+        </aside>
+      </section>
+    </div>
+  )
+}

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,0 +1,140 @@
+import { useMemo, useState } from 'react'
+
+export default function LoginPage({ onLogin, onRegister }) {
+  const [mode, setMode] = useState('login')
+  const [form, setForm] = useState({ name: '', email: '', password: '' })
+  const [error, setError] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const title = useMemo(
+    () => (mode === 'login' ? 'Sign in to Pasha Law Senate' : 'Create your Pasha Law Senate account'),
+    [mode]
+  )
+
+  const description =
+    mode === 'login'
+      ? 'Secure portal for case tracking, client management, and firm operations.'
+      : 'Set up your secure access to manage matters, clients, and team collaboration.'
+
+  const handleChange = (event) => {
+    const { name, value } = event.target
+    setForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    setError('')
+    setIsSubmitting(true)
+    try {
+      const handler = mode === 'login' ? onLogin : onRegister
+      if (typeof handler !== 'function') {
+        throw new Error('Authentication handler is not available.')
+      }
+
+      const payload =
+        mode === 'login'
+          ? { email: form.email, password: form.password }
+          : { name: form.name, email: form.email, password: form.password }
+
+      const result = await handler(payload)
+      if (!result?.success) {
+        setError(
+          result?.error ||
+            (mode === 'login'
+              ? 'Unable to sign in. Please try again.'
+              : 'Unable to create your account. Please try again.')
+        )
+        return
+      }
+    } catch (err) {
+      console.error(err)
+      setError(err?.message || 'An unexpected error occurred. Please try again.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-100 via-white to-slate-100">
+      <div className="max-w-md w-full bg-white/90 backdrop-blur rounded-3xl border border-slate-200 shadow-lg p-8 space-y-6">
+        <header className="space-y-2 text-center">
+          <h1 className="text-2xl font-semibold text-slate-900">{title}</h1>
+          <p className="text-sm text-slate-500">{description}</p>
+        </header>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          {mode === 'register' && (
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-slate-700" htmlFor="name">
+                Full name
+              </label>
+              <input
+                id="name"
+                name="name"
+                type="text"
+                className="input"
+                placeholder="Your name"
+                autoComplete="name"
+                value={form.name}
+                onChange={handleChange}
+              />
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-slate-700" htmlFor="email">Email</label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              className="input"
+              placeholder="you@pashalawsenate.com"
+              autoComplete={mode === 'login' ? 'username' : 'email'}
+              value={form.email}
+              onChange={handleChange}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-slate-700" htmlFor="password">Password</label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              className="input"
+              placeholder="Enter your password"
+              autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
+              value={form.password}
+              onChange={handleChange}
+            />
+          </div>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <button type="submit" className="btn btn-primary w-full" disabled={isSubmitting}>
+            {isSubmitting ? (mode === 'login' ? 'Signing in…' : 'Creating account…') : mode === 'login' ? 'Sign in' : 'Create account'}
+          </button>
+        </form>
+
+        <div className="text-xs text-slate-400 text-center space-y-1">
+          <p>
+            {mode === 'login'
+              ? 'Protected access. Contact the firm administrator to reset your credentials.'
+              : 'Only trusted firm staff should create accounts. Passwords must remain confidential.'}
+          </p>
+          <button
+            type="button"
+            className="text-sky-600 hover:text-sky-700 font-medium"
+            onClick={() => {
+              setMode((current) => (current === 'login' ? 'register' : 'login'))
+              setError('')
+              setIsSubmitting(false)
+            }}
+          >
+            {mode === 'login' ? 'Need an account? Create one now.' : 'Already registered? Sign in instead.'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/ResourcesPage.jsx
+++ b/src/pages/ResourcesPage.jsx
@@ -1,0 +1,307 @@
+import { useState } from 'react'
+import { usePortalData } from '../store/portalData'
+
+const defaultResourceForm = {
+  title: '',
+  type: '',
+  link: '',
+  owner: '',
+  notes: '',
+}
+
+const defaultDeskForm = {
+  department: '',
+  phone: '',
+  email: '',
+  hours: '',
+  notes: '',
+}
+
+export default function ResourcesPage() {
+  const resources = usePortalData((state) => state.data.resources)
+  const supportDesks = usePortalData((state) => state.data.supportDesks)
+  const team = usePortalData((state) => state.data.team)
+  const addResource = usePortalData((state) => state.addResource)
+  const removeResource = usePortalData((state) => state.removeResource)
+  const addSupportDesk = usePortalData((state) => state.addSupportDesk)
+  const removeSupportDesk = usePortalData((state) => state.removeSupportDesk)
+
+  const [resourceForm, setResourceForm] = useState(defaultResourceForm)
+  const [deskForm, setDeskForm] = useState(defaultDeskForm)
+  const [isAddingResource, setIsAddingResource] = useState(false)
+  const [isAddingDesk, setIsAddingDesk] = useState(false)
+  const [removingResourceId, setRemovingResourceId] = useState(null)
+  const [removingDeskId, setRemovingDeskId] = useState(null)
+
+  const handleResourceChange = (event) => {
+    const { name, value } = event.target
+    setResourceForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleResourceSubmit = async (event) => {
+    event.preventDefault()
+    if (!resourceForm.title) return
+    setIsAddingResource(true)
+    try {
+      await addResource(resourceForm)
+      setResourceForm(defaultResourceForm)
+    } catch (error) {
+      console.error('Failed to add resource', error)
+    } finally {
+      setIsAddingResource(false)
+    }
+  }
+
+  const handleDeskChange = (event) => {
+    const { name, value } = event.target
+    setDeskForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleDeskSubmit = async (event) => {
+    event.preventDefault()
+    if (!deskForm.department) return
+    setIsAddingDesk(true)
+    try {
+      await addSupportDesk(deskForm)
+      setDeskForm(defaultDeskForm)
+    } catch (error) {
+      console.error('Failed to add support desk', error)
+    } finally {
+      setIsAddingDesk(false)
+    }
+  }
+
+  const handleResourceRemove = async (id) => {
+    setRemovingResourceId(id)
+    try {
+      await removeResource(id)
+    } catch (error) {
+      console.error('Failed to remove resource', error)
+    } finally {
+      setRemovingResourceId(null)
+    }
+  }
+
+  const handleDeskRemove = async (id) => {
+    setRemovingDeskId(id)
+    try {
+      await removeSupportDesk(id)
+    } catch (error) {
+      console.error('Failed to remove support desk', error)
+    } finally {
+      setRemovingDeskId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Firm operations &amp; resources</h1>
+        <p className="text-sm text-slate-500">Upload the templates, contacts, and guides your team depends on.</p>
+      </header>
+
+      <section className="card p-6 space-y-4">
+        <h2 className="text-lg font-semibold">Resource library</h2>
+        <form className="grid gap-4 md:grid-cols-3" onSubmit={handleResourceSubmit}>
+          <label className="space-y-2 text-sm md:col-span-1">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Title</span>
+            <input
+              name="title"
+              className="input"
+              value={resourceForm.title}
+              onChange={handleResourceChange}
+              placeholder="Court filing checklist"
+              required
+            />
+          </label>
+          <label className="space-y-2 text-sm">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Category</span>
+            <input
+              name="type"
+              className="input"
+              value={resourceForm.type}
+              onChange={handleResourceChange}
+              placeholder="Template, policy, guide"
+            />
+          </label>
+          <label className="space-y-2 text-sm">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Owner</span>
+            <input
+              name="owner"
+              className="input"
+              value={resourceForm.owner}
+              onChange={handleResourceChange}
+              placeholder="Assigned team"
+            />
+          </label>
+          <label className="space-y-2 text-sm md:col-span-2">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Link</span>
+            <input
+              name="link"
+              className="input"
+              value={resourceForm.link}
+              onChange={handleResourceChange}
+              placeholder="https://drive.google.com/..."
+            />
+          </label>
+          <label className="space-y-2 text-sm md:col-span-3">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Notes</span>
+            <textarea
+              name="notes"
+              className="input min-h-[80px]"
+              value={resourceForm.notes}
+              onChange={handleResourceChange}
+              placeholder="Brief description, version history, or access notes"
+            />
+          </label>
+          <div className="md:col-span-3 flex justify-end">
+            <button type="submit" className="btn btn-primary" disabled={isAddingResource}>
+              {isAddingResource ? 'Saving…' : 'Add resource'}
+            </button>
+          </div>
+        </form>
+        <div className="grid gap-4 md:grid-cols-2">
+          {resources.length === 0 ? (
+            <p className="text-sm text-slate-500">No resources uploaded yet.</p>
+          ) : (
+            resources.map((item) => (
+              <article key={item.id} className="card p-5 space-y-2">
+                <header className="flex items-start justify-between gap-3">
+                  <div>
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white">{item.title}</h3>
+                    <div className="text-xs uppercase tracking-wide text-slate-400">
+                      {[item.type, item.owner].filter(Boolean).join(' • ')}
+                    </div>
+                    {item.notes && <p className="text-sm text-slate-500">{item.notes}</p>}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleResourceRemove(item.id)}
+                    className="text-xs text-red-500 hover:text-red-600"
+                    disabled={removingResourceId === item.id}
+                  >
+                    {removingResourceId === item.id ? 'Removing…' : 'Remove'}
+                  </button>
+                </header>
+                {item.link && (
+                  <a href={item.link} className="text-sm text-brand-600 hover:underline" target="_blank" rel="noreferrer">
+                    Open reference
+                  </a>
+                )}
+              </article>
+            ))
+          )}
+        </div>
+      </section>
+
+      <section className="card p-6 space-y-4">
+        <h2 className="text-lg font-semibold">Support desks</h2>
+        <form className="grid gap-4 md:grid-cols-3" onSubmit={handleDeskSubmit}>
+          <label className="space-y-2 text-sm">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Desk name</span>
+            <input
+              name="department"
+              className="input"
+              value={deskForm.department}
+              onChange={handleDeskChange}
+              placeholder="Court filings desk"
+              required
+            />
+          </label>
+          <label className="space-y-2 text-sm">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Phone</span>
+            <input
+              name="phone"
+              className="input"
+              value={deskForm.phone}
+              onChange={handleDeskChange}
+              placeholder="Contact number"
+            />
+          </label>
+          <label className="space-y-2 text-sm">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Email</span>
+            <input
+              type="email"
+              name="email"
+              className="input"
+              value={deskForm.email}
+              onChange={handleDeskChange}
+              placeholder="team@firm.com"
+            />
+          </label>
+          <label className="space-y-2 text-sm">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Hours</span>
+            <input
+              name="hours"
+              className="input"
+              value={deskForm.hours}
+              onChange={handleDeskChange}
+              placeholder="Weekdays 9am - 6pm"
+            />
+          </label>
+          <label className="space-y-2 text-sm md:col-span-3">
+            <span className="block font-medium text-slate-600 dark:text-slate-300">Notes</span>
+            <textarea
+              name="notes"
+              className="input min-h-[80px]"
+              value={deskForm.notes}
+              onChange={handleDeskChange}
+              placeholder="Availability hours, turnaround times, or responsibilities"
+            />
+          </label>
+          <div className="md:col-span-3 flex justify-end">
+            <button type="submit" className="btn btn-primary" disabled={isAddingDesk}>
+              {isAddingDesk ? 'Saving…' : 'Add support desk'}
+            </button>
+          </div>
+        </form>
+        <div className="grid gap-4 md:grid-cols-2">
+          {supportDesks.length === 0 ? (
+            <p className="text-sm text-slate-500">No support desks added yet.</p>
+          ) : (
+            supportDesks.map((desk) => (
+              <article key={desk.id} className="card p-5 space-y-2">
+                <header className="flex items-start justify-between gap-3">
+                  <div>
+                    <h3 className="text-base font-semibold text-slate-900 dark:text-white">{desk.department}</h3>
+                    <div className="text-xs text-slate-500 space-y-1">
+                      {desk.phone && <p>Phone: {desk.phone}</p>}
+                      {desk.email && <p>Email: {desk.email}</p>}
+                      {desk.hours && <p>Hours: {desk.hours}</p>}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleDeskRemove(desk.id)}
+                    className="text-xs text-red-500 hover:text-red-600"
+                    disabled={removingDeskId === desk.id}
+                  >
+                    {removingDeskId === desk.id ? 'Removing…' : 'Remove'}
+                  </button>
+                </header>
+                {desk.notes && <p className="text-sm text-slate-500">{desk.notes}</p>}
+              </article>
+            ))
+          )}
+        </div>
+      </section>
+
+      <section className="card p-6 space-y-3 text-sm text-slate-600 dark:text-slate-300">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Emergency contacts</h2>
+        {team.length === 0 ? (
+          <p className="text-slate-500">Add key contacts from the dashboard to see them listed here.</p>
+        ) : (
+          <ul className="list-disc pl-5 space-y-2">
+            {team.map((member) => (
+              <li key={member.id}>
+                {member.name}
+                {member.phone && <span> — {member.phone}</span>}
+                {member.email && <span className="text-slate-500"> • {member.email}</span>}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/pages/UpcomingCasesPage.jsx
+++ b/src/pages/UpcomingCasesPage.jsx
@@ -1,0 +1,55 @@
+import dayjs from 'dayjs'
+import { usePortalData } from '../store/portalData'
+
+export default function UpcomingCasesPage() {
+  const cases = usePortalData((state) => state.data.cases)
+
+  const timeline = cases
+    .filter((item) => item.nextDate)
+    .slice()
+    .sort((a, b) => new Date(a.nextDate) - new Date(b.nextDate))
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Upcoming hearings timeline</h1>
+        <p className="text-sm text-slate-500">Matters appear here as soon as you capture a future hearing date.</p>
+      </header>
+
+      <div className="card p-6 space-y-6">
+        {timeline.length === 0 ? (
+          <p className="text-sm text-slate-500">No hearings scheduled yet. Add next hearing dates inside the Cases tab.</p>
+        ) : (
+          <ol className="relative border-l border-slate-200 dark:border-slate-700 pl-6 space-y-6">
+            {timeline.map((item) => (
+              <li key={item.id} className="ml-4">
+                <div className="absolute -left-1 mt-1 h-3 w-3 rounded-full border-2 border-white bg-brand-600" />
+                <p className="text-xs uppercase tracking-wide text-slate-500">
+                  {dayjs(item.nextDate).format('dddd, DD MMM YYYY')}
+                </p>
+                <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
+                  {item.client} vs {item.opponent || '—'}
+                </h2>
+                <p className="text-sm text-slate-500">{item.courtroom || 'Courtroom details pending'}</p>
+                <div className="mt-2 grid gap-x-6 gap-y-2 sm:grid-cols-3 text-sm text-slate-600 dark:text-slate-300">
+                  <div>
+                    <p className="font-medium text-slate-500">Status</p>
+                    <p>{item.status || '—'}</p>
+                  </div>
+                  <div>
+                    <p className="font-medium text-slate-500">Preparation</p>
+                    <p>{item.notes || 'Add preparation notes inside the case file.'}</p>
+                  </div>
+                  <div>
+                    <p className="font-medium text-slate-500">Practice area</p>
+                    <p>{item.practiceArea || '—'}</p>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/store/portalData.js
+++ b/src/store/portalData.js
@@ -1,0 +1,763 @@
+import { create } from 'zustand'
+import { api } from '../lib/api'
+
+const STORAGE_KEY = 'pls-portal-data'
+const UNSYNCED_KEY = 'pls-portal-unsynced'
+const OFFLINE_NOTICE =
+  'The portal server is unavailable. Changes will be stored locally in this browser until a connection is restored.'
+
+const coerceNumber = (value, fallback = 0) => {
+  if (value === null || value === undefined || value === '') return fallback
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+const normaliseStats = (value = {}) => ({
+  activeMatters: coerceNumber(value.activeMatters),
+  hearingsThisWeek: coerceNumber(value.hearingsThisWeek),
+  filingsPending: coerceNumber(value.filingsPending),
+  teamUtilisation: coerceNumber(value.teamUtilisation),
+})
+
+const mergeStats = (current, patch = {}) => {
+  const base = normaliseStats(current)
+  return {
+    activeMatters: coerceNumber(patch.activeMatters ?? base.activeMatters, base.activeMatters),
+    hearingsThisWeek: coerceNumber(patch.hearingsThisWeek ?? base.hearingsThisWeek, base.hearingsThisWeek),
+    filingsPending: coerceNumber(patch.filingsPending ?? base.filingsPending, base.filingsPending),
+    teamUtilisation: coerceNumber(patch.teamUtilisation ?? base.teamUtilisation, base.teamUtilisation),
+  }
+}
+
+const normaliseCollection = (value) => (Array.isArray(value) ? value : [])
+
+const createDefaultData = () => ({
+  stats: normaliseStats(),
+  cases: [],
+  clients: [],
+  tasks: [],
+  team: [],
+  resources: [],
+  supportDesks: [],
+})
+
+const normalisePortalData = (value) => {
+  if (!value || typeof value !== 'object') {
+    return createDefaultData()
+  }
+  return {
+    stats: normaliseStats(value.stats),
+    cases: normaliseCollection(value.cases),
+    clients: normaliseCollection(value.clients),
+    tasks: normaliseCollection(value.tasks),
+    team: normaliseCollection(value.team),
+    resources: normaliseCollection(value.resources),
+    supportDesks: normaliseCollection(value.supportDesks),
+  }
+}
+
+const getStorage = () => {
+  if (typeof window === 'undefined') return null
+  try {
+    const { localStorage } = window
+    const probe = '__pls_probe__'
+    localStorage.setItem(probe, '1')
+    localStorage.removeItem(probe)
+    return localStorage
+  } catch (error) {
+    console.warn('Local storage is not available.', error)
+    return null
+  }
+}
+
+const persistLocalData = (data) => {
+  const storage = getStorage()
+  if (!storage) return
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(normalisePortalData(data)))
+  } catch (error) {
+    console.warn('Failed to persist portal data locally.', error)
+  }
+}
+
+const readLocalData = () => {
+  const storage = getStorage()
+  if (!storage) return createDefaultData()
+  try {
+    const raw = storage.getItem(STORAGE_KEY)
+    if (!raw) return createDefaultData()
+    return normalisePortalData(JSON.parse(raw))
+  } catch (error) {
+    console.warn('Failed to read stored portal data.', error)
+    return createDefaultData()
+  }
+}
+
+const hasPortalContent = (data) => {
+  const snapshot = normalisePortalData(data)
+  if (!snapshot) return false
+
+  if (
+    snapshot.cases.length ||
+    snapshot.clients.length ||
+    snapshot.tasks.length ||
+    snapshot.team.length ||
+    snapshot.resources.length ||
+    snapshot.supportDesks.length
+  ) {
+    return true
+  }
+
+  return Object.values(snapshot.stats || {}).some((value) => Number(value) > 0)
+}
+
+const initialData = readLocalData()
+
+const writeUnsyncedFlag = (value) => {
+  const storage = getStorage()
+  if (!storage) return
+  if (value) {
+    storage.setItem(UNSYNCED_KEY, '1')
+  } else {
+    storage.removeItem(UNSYNCED_KEY)
+  }
+}
+
+const readUnsyncedFlag = () => {
+  const storage = getStorage()
+  if (!storage) return false
+  return storage.getItem(UNSYNCED_KEY) === '1'
+}
+
+const generateId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+const isNetworkError = (error) =>
+  error?.code === 'API_UNAVAILABLE' ||
+  error?.message === 'Unable to reach the server. Please try again.' ||
+  error?.cause instanceof TypeError
+
+const timestamp = () => new Date().toISOString()
+
+const createLocalCase = (payload) => ({
+  id: payload.id || generateId(),
+  caseNumber: String(payload.caseNumber || ''),
+  client: String(payload.client || ''),
+  opponent: payload.opponent ? String(payload.opponent) : '',
+  practiceArea: payload.practiceArea ? String(payload.practiceArea) : '',
+  nextDate: payload.nextDate || '',
+  status: payload.status ? String(payload.status) : '',
+  courtroom: payload.courtroom ? String(payload.courtroom) : '',
+  notes: payload.notes ? String(payload.notes) : '',
+  createdAt: payload.createdAt || timestamp(),
+})
+
+const createLocalClient = (payload) => ({
+  id: payload.id || generateId(),
+  organisation: String(payload.organisation || ''),
+  primaryContact: payload.primaryContact ? String(payload.primaryContact) : '',
+  email: payload.email ? String(payload.email) : '',
+  phone: payload.phone ? String(payload.phone) : '',
+  address: payload.address ? String(payload.address) : '',
+  notes: payload.notes ? String(payload.notes) : '',
+  createdAt: payload.createdAt || timestamp(),
+})
+
+const createLocalTask = (payload) => ({
+  id: payload.id || generateId(),
+  title: String(payload.title || ''),
+  owner: String(payload.owner || ''),
+  due: payload.due || '',
+  createdAt: payload.createdAt || timestamp(),
+})
+
+const createLocalTeamMember = (payload) => ({
+  id: payload.id || generateId(),
+  name: String(payload.name || ''),
+  role: payload.role ? String(payload.role) : '',
+  phone: payload.phone ? String(payload.phone) : '',
+  email: payload.email ? String(payload.email) : '',
+  createdAt: payload.createdAt || timestamp(),
+})
+
+const createLocalResource = (payload) => ({
+  id: payload.id || generateId(),
+  title: String(payload.title || ''),
+  type: payload.type ? String(payload.type) : '',
+  link: payload.link ? String(payload.link) : '',
+  owner: payload.owner ? String(payload.owner) : '',
+  notes: payload.notes ? String(payload.notes) : '',
+  createdAt: payload.createdAt || timestamp(),
+})
+
+const createLocalSupportDesk = (payload) => ({
+  id: payload.id || generateId(),
+  department: String(payload.department || ''),
+  phone: payload.phone ? String(payload.phone) : '',
+  email: payload.email ? String(payload.email) : '',
+  hours: payload.hours ? String(payload.hours) : '',
+  notes: payload.notes ? String(payload.notes) : '',
+  createdAt: payload.createdAt || timestamp(),
+})
+
+export const usePortalData = create((set, get) => {
+  const markUnsynced = (value) => {
+    writeUnsyncedFlag(value)
+    set({ unsynced: value })
+  }
+
+  const applyLocalUpdate = (updater) => {
+    set((state) => {
+      const current = state.data
+      const nextData = normalisePortalData(updater(current))
+      persistLocalData(nextData)
+      return {
+        data: nextData,
+        hasCache: hasPortalContent(nextData),
+      }
+    })
+  }
+
+  const activateOfflineMode = (message = OFFLINE_NOTICE) => {
+    set({
+      mode: 'local',
+      notice: message,
+      error: null,
+    })
+  }
+
+  const clearOfflineNotice = () => {
+    set({ notice: '' })
+  }
+
+  return {
+    data: initialData,
+    isLoading: false,
+    hasLoaded: false,
+    error: null,
+    notice: '',
+    mode: 'unknown',
+    hasCache: hasPortalContent(initialData),
+    unsynced: readUnsyncedFlag(),
+    clearError() {
+      set({ error: null })
+    },
+    clearNotice() {
+      clearOfflineNotice()
+    },
+    async load() {
+      if (get().isLoading) return
+      set({ isLoading: true, error: null })
+      const snapshot = normalisePortalData(get().data)
+
+      if (get().unsynced) {
+        try {
+          const synced = normalisePortalData(await api.savePortal(snapshot))
+          persistLocalData(synced)
+          markUnsynced(false)
+          set({ data: synced, mode: 'api', notice: '', hasCache: hasPortalContent(synced) })
+        } catch (error) {
+          if (isNetworkError(error)) {
+            set({
+              data: snapshot,
+              isLoading: false,
+              hasLoaded: true,
+              mode: 'local',
+              notice: OFFLINE_NOTICE,
+              error: null,
+              hasCache: hasPortalContent(snapshot),
+            })
+            return snapshot
+          }
+
+          set({
+            isLoading: false,
+            error: error.message || 'Unable to sync offline changes.',
+          })
+          throw error
+        }
+      }
+
+      try {
+        const response = await api.getPortal()
+        const data = normalisePortalData(response)
+        persistLocalData(data)
+        markUnsynced(false)
+        set({
+          data,
+          isLoading: false,
+          hasLoaded: true,
+          mode: 'api',
+          notice: '',
+          error: null,
+          hasCache: hasPortalContent(data),
+        })
+        return data
+      } catch (error) {
+        const localData = readLocalData()
+        persistLocalData(localData)
+        if (isNetworkError(error)) {
+          console.warn('Falling back to offline portal data.', error)
+          set({
+            data: localData,
+            isLoading: false,
+            hasLoaded: true,
+            mode: 'local',
+            notice: OFFLINE_NOTICE,
+            error: null,
+            hasCache: hasPortalContent(localData),
+          })
+        } else {
+          console.error('Failed to load portal data from API.', error)
+          set({
+            data: localData,
+            isLoading: false,
+            hasLoaded: true,
+            error: error.message || 'Unable to load portal data.',
+            hasCache: hasPortalContent(localData),
+          })
+        }
+
+        return localData
+      }
+    },
+    async refresh() {
+      return get().load()
+    },
+    async reset() {
+      const defaults = createDefaultData()
+      persistLocalData(defaults)
+      if (get().mode === 'local') {
+        markUnsynced(true)
+        set((state) => ({
+          data: defaults,
+          hasLoaded: true,
+          error: null,
+          notice: state.mode === 'local' ? OFFLINE_NOTICE : state.notice,
+          hasCache: hasPortalContent(defaults),
+        }))
+        return
+      }
+
+      try {
+        const saved = normalisePortalData(await api.savePortal(defaults))
+        persistLocalData(saved)
+        markUnsynced(false)
+        set({ data: saved, hasLoaded: true, error: null, notice: '', hasCache: hasPortalContent(saved) })
+      } catch (error) {
+        if (isNetworkError(error)) {
+          activateOfflineMode()
+          markUnsynced(true)
+          set({ data: defaults, hasLoaded: true, error: null, hasCache: hasPortalContent(defaults) })
+          return
+        }
+        set({ error: error.message || 'Unable to reset portal data.' })
+        throw error
+      }
+    },
+    async updateStats(patch) {
+      set({ error: null })
+      const apply = (input) =>
+        applyLocalUpdate((data) => ({
+          ...data,
+          stats: mergeStats(data.stats, input),
+        }))
+
+      if (get().mode === 'local') {
+        apply(patch)
+        markUnsynced(true)
+        return
+      }
+
+      try {
+        const response = await api.updateStats(patch)
+        apply(response.stats)
+      } catch (error) {
+        if (isNetworkError(error)) {
+          activateOfflineMode()
+          apply(patch)
+          markUnsynced(true)
+          return
+        }
+        set({ error: error.message || 'Unable to update metrics.' })
+        throw error
+      }
+    },
+    async addCase(values) {
+      set({ error: null })
+      const pushLocal = (item) => {
+        applyLocalUpdate((data) => ({
+          ...data,
+          cases: [item, ...data.cases.filter((existing) => existing.id !== item.id)],
+        }))
+      }
+
+      if (get().mode === 'local') {
+        const localItem = createLocalCase(values)
+        pushLocal(localItem)
+        markUnsynced(true)
+        return localItem.id
+      }
+
+      try {
+        const created = await api.createCase(values)
+        const mapped = createLocalCase(created)
+        pushLocal(mapped)
+        return mapped.id
+      } catch (error) {
+        if (isNetworkError(error)) {
+          activateOfflineMode()
+          const localItem = createLocalCase(values)
+          pushLocal(localItem)
+          markUnsynced(true)
+          return localItem.id
+        }
+        set({ error: error.message || 'Unable to add case.' })
+        throw error
+      }
+    },
+    async removeCase(id) {
+      set({ error: null })
+      const removeLocal = () => {
+        applyLocalUpdate((data) => ({
+          ...data,
+          cases: data.cases.filter((item) => item.id !== id),
+        }))
+      }
+
+      if (get().mode === 'local') {
+        removeLocal()
+        markUnsynced(true)
+        return
+      }
+
+      try {
+        await api.deleteCase(id)
+        removeLocal()
+      } catch (error) {
+        if (isNetworkError(error)) {
+          activateOfflineMode()
+          removeLocal()
+          markUnsynced(true)
+          return
+        }
+        set({ error: error.message || 'Unable to remove case.' })
+        throw error
+      }
+    },
+    async addClient(values) {
+      set({ error: null })
+      const pushLocal = (item) => {
+        applyLocalUpdate((data) => ({
+          ...data,
+          clients: [item, ...data.clients.filter((existing) => existing.id !== item.id)],
+        }))
+      }
+
+      if (get().mode === 'local') {
+        const localItem = createLocalClient(values)
+        pushLocal(localItem)
+        markUnsynced(true)
+        return localItem.id
+      }
+
+      try {
+        const created = await api.createClient(values)
+        const mapped = createLocalClient(created)
+        pushLocal(mapped)
+        return mapped.id
+      } catch (error) {
+        if (isNetworkError(error)) {
+          activateOfflineMode()
+          const localItem = createLocalClient(values)
+          pushLocal(localItem)
+          markUnsynced(true)
+          return localItem.id
+        }
+        set({ error: error.message || 'Unable to add client.' })
+        throw error
+      }
+    },
+    async removeClient(id) {
+      set({ error: null })
+      const removeLocal = () => {
+        applyLocalUpdate((data) => ({
+          ...data,
+          clients: data.clients.filter((item) => item.id !== id),
+        }))
+      }
+
+      if (get().mode === 'local') {
+        removeLocal()
+        markUnsynced(true)
+        return
+      }
+
+      try {
+        await api.deleteClient(id)
+        removeLocal()
+      } catch (error) {
+        if (isNetworkError(error)) {
+          activateOfflineMode()
+          removeLocal()
+          markUnsynced(true)
+          return
+        }
+        set({ error: error.message || 'Unable to remove client.' })
+        throw error
+      }
+    },
+    async addTask(values) {
+      set({ error: null })
+      const pushLocal = (item) => {
+        applyLocalUpdate((data) => ({
+          ...data,
+          tasks: [item, ...data.tasks.filter((existing) => existing.id !== item.id)],
+        }))
+      }
+
+      if (get().mode === 'local') {
+        const localItem = createLocalTask(values)
+        pushLocal(localItem)
+        markUnsynced(true)
+        return localItem.id
+      }
+
+      try {
+        const created = await api.createTask(values)
+        const mapped = createLocalTask(created)
+        pushLocal(mapped)
+        return mapped.id
+      } catch (error) {
+        if (isNetworkError(error)) {
+          activateOfflineMode()
+          const localItem = createLocalTask(values)
+          pushLocal(localItem)
+          markUnsynced(true)
+          return localItem.id
+        }
+        set({ error: error.message || 'Unable to add task.' })
+        throw error
+      }
+    },
+    async removeTask(id) {
+      set({ error: null })
+      const removeLocal = () => {
+        applyLocalUpdate((data) => ({
+          ...data,
+          tasks: data.tasks.filter((item) => item.id !== id),
+        }))
+      }
+
+      if (get().mode === 'local') {
+        removeLocal()
+        markUnsynced(true)
+        return
+      }
+
+      try {
+        await api.deleteTask(id)
+        removeLocal()
+      } catch (error) {
+        if (isNetworkError(error)) {
+          activateOfflineMode()
+          removeLocal()
+          markUnsynced(true)
+          return
+        }
+        set({ error: error.message || 'Unable to remove task.' })
+        throw error
+      }
+    },
+    async addTeamMember(values) {
+      set({ error: null })
+      const pushLocal = (item) => {
+        applyLocalUpdate((data) => ({
+          ...data,
+          team: [item, ...data.team.filter((existing) => existing.id !== item.id)],
+        }))
+      }
+
+      if (get().mode === 'local') {
+        const localItem = createLocalTeamMember(values)
+        pushLocal(localItem)
+        markUnsynced(true)
+        return localItem.id
+      }
+
+      try {
+        const created = await api.createTeamMember(values)
+        const mapped = createLocalTeamMember(created)
+        pushLocal(mapped)
+        return mapped.id
+      } catch (error) {
+        if (isNetworkError(error)) {
+          activateOfflineMode()
+          const localItem = createLocalTeamMember(values)
+          pushLocal(localItem)
+          markUnsynced(true)
+          return localItem.id
+        }
+        set({ error: error.message || 'Unable to add team member.' })
+        throw error
+      }
+    },
+    async removeTeamMember(id) {
+      set({ error: null })
+      const removeLocal = () => {
+        applyLocalUpdate((data) => ({
+          ...data,
+          team: data.team.filter((item) => item.id !== id),
+        }))
+      }
+
+      if (get().mode === 'local') {
+        removeLocal()
+        markUnsynced(true)
+        return
+      }
+
+      try {
+        await api.deleteTeamMember(id)
+        removeLocal()
+      } catch (error) {
+        if (isNetworkError(error)) {
+          activateOfflineMode()
+          removeLocal()
+          markUnsynced(true)
+          return
+        }
+        set({ error: error.message || 'Unable to remove team member.' })
+        throw error
+      }
+    },
+    async addResource(values) {
+      set({ error: null })
+      const pushLocal = (item) => {
+        applyLocalUpdate((data) => ({
+          ...data,
+          resources: [item, ...data.resources.filter((existing) => existing.id !== item.id)],
+        }))
+      }
+
+      if (get().mode === 'local') {
+        const localItem = createLocalResource(values)
+        pushLocal(localItem)
+        markUnsynced(true)
+        return localItem.id
+      }
+
+      try {
+        const created = await api.createResource(values)
+        const mapped = createLocalResource(created)
+        pushLocal(mapped)
+        return mapped.id
+      } catch (error) {
+        if (isNetworkError(error)) {
+          activateOfflineMode()
+          const localItem = createLocalResource(values)
+          pushLocal(localItem)
+          markUnsynced(true)
+          return localItem.id
+        }
+        set({ error: error.message || 'Unable to add resource.' })
+        throw error
+      }
+    },
+    async removeResource(id) {
+      set({ error: null })
+      const removeLocal = () => {
+        applyLocalUpdate((data) => ({
+          ...data,
+          resources: data.resources.filter((item) => item.id !== id),
+        }))
+      }
+
+      if (get().mode === 'local') {
+        removeLocal()
+        markUnsynced(true)
+        return
+      }
+
+      try {
+        await api.deleteResource(id)
+        removeLocal()
+      } catch (error) {
+        if (isNetworkError(error)) {
+          activateOfflineMode()
+          removeLocal()
+          markUnsynced(true)
+          return
+        }
+        set({ error: error.message || 'Unable to remove resource.' })
+        throw error
+      }
+    },
+    async addSupportDesk(values) {
+      set({ error: null })
+      const pushLocal = (item) => {
+        applyLocalUpdate((data) => ({
+          ...data,
+          supportDesks: [item, ...data.supportDesks.filter((existing) => existing.id !== item.id)],
+        }))
+      }
+
+      if (get().mode === 'local') {
+        const localItem = createLocalSupportDesk(values)
+        pushLocal(localItem)
+        markUnsynced(true)
+        return localItem.id
+      }
+
+      try {
+        const created = await api.createSupportDesk(values)
+        const mapped = createLocalSupportDesk(created)
+        pushLocal(mapped)
+        return mapped.id
+      } catch (error) {
+        if (isNetworkError(error)) {
+          activateOfflineMode()
+          const localItem = createLocalSupportDesk(values)
+          pushLocal(localItem)
+          markUnsynced(true)
+          return localItem.id
+        }
+        set({ error: error.message || 'Unable to add support desk.' })
+        throw error
+      }
+    },
+    async removeSupportDesk(id) {
+      set({ error: null })
+      const removeLocal = () => {
+        applyLocalUpdate((data) => ({
+          ...data,
+          supportDesks: data.supportDesks.filter((item) => item.id !== id),
+        }))
+      }
+
+      if (get().mode === 'local') {
+        removeLocal()
+        markUnsynced(true)
+        return
+      }
+
+      try {
+        await api.deleteSupportDesk(id)
+        removeLocal()
+      } catch (error) {
+        if (isNetworkError(error)) {
+          activateOfflineMode()
+          removeLocal()
+          markUnsynced(true)
+          return
+        }
+        set({ error: error.message || 'Unable to remove support desk.' })
+        throw error
+      }
+    },
+  }
+})


### PR DESCRIPTION
## Summary
- detect when locally cached portal records exist and track that state in the store
- keep the cache flag in sync whenever local updates, API fetches, or resets adjust the portal dataset
- render the dashboard routes immediately when cached data is available so offline edits persist across reloads

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ef33ae2fd483289f1b4bba3d06428b